### PR TITLE
Fix off by one in spi dump

### DIFF
--- a/host/greatfet/commands/greatfet_spiflash.py
+++ b/host/greatfet/commands/greatfet_spiflash.py
@@ -93,7 +93,7 @@ def dump_flash(device, address=None, length=None, filename="flash.bin", log_func
             data = device.vendor_request_in(vendor_requests.SPI_DUMP_FLASH,
                                             length=block_length, index=index, value=value)
             file.write(data)
-            address += 255
+            address += 256
 
 def i2c_xfer(device, log_function):
     log_function("Starting I2C")


### PR DESCRIPTION
Need to increment by 256 rather than 255 to make the address of the next
block the address after the end of the current one. This fixes a bug
where the last byte of a block is always repeated as the first byte of
the next.