### PR TITLE
Fix firmware build documentation

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -37,7 +37,7 @@ cd greatfet_usb
 mkdir build
 cd build
 cmake .. -DBOARD=GREATFET_ONE
-make greatfet_usb
+make
 ```
 
 If building for another board, replace ```GREATFET_ONE``` with the the


### PR DESCRIPTION
The firmware build instructions are broken. CMake doesn't automatically create a target by the same name of the project, so `greatfet_usb` is not a target generated by CMake. 