### PR TITLE
Some changes to SPI bus frequency code

### DIFF
--- a/firmware/greatfet_usb/usb_api_spi.c
+++ b/firmware/greatfet_usb/usb_api_spi.c
@@ -49,7 +49,7 @@ usb_request_status_t usb_vendor_request_spi_init(
 		uint8_t cpsdvsr = endpoint->setup.value_l;
 
 		config = (ssp_config_t *)&ssp1_config_spi;
-		if ((scr != 0) && (cpsdvsr != 0)) {
+		if (cpsdvsr != 0) {
 			local_spi_config.data_bits = SSP_DATA_8BITS;
 			local_spi_config.clock_prescale_rate = cpsdvsr;
 			local_spi_config.serial_clock_rate = scr;

--- a/host/greatfet/peripherals/spi_bus.py
+++ b/host/greatfet/peripherals/spi_bus.py
@@ -13,19 +13,47 @@ class SPIBus(GreatFETPeripheral):
         is being used to control the onboard flash.
     """
 
-    def __init__(self, board, name='spi bus', buffer_size=255,
+    class FREQ():
+        """
+            Set of predefined frequencies used to configure the SPI bus. It
+            contains tuple of clock_prescale_rate & serial_clock_rate. All of
+            these frequencies assume that the PCLK is set to 204 MHz
+        """
+        C204000Hz       = (100, 9)
+        C408000Hz       = (100, 4)
+        C680000Hz       = (100, 2)
+        C1020000Hz      = (100, 1)
+        C2040000Hz      = (50, 1)
+        C4250000Hz      = (24, 1)
+        C8500000Hz      = (12, 1)
+        C12750000Hz     = (8, 1)
+        C17000000Hz     = (6, 1)
+        C20400000Hz     = (2, 4)
+        C25500000Hz     = (4, 1)
+        C34000000Hz     = (2, 2)
+        C51000000Hz     = (2, 1)
+        C102000000Hz    = (2, 0)
+
+
+
+    def __init__(self, board, name='spi bus', buffer_size=255, freq_preset=0,
                  serial_clock_rate=2, clock_prescale_rate=100):
         """
         Initialize a new SPI bus.
 
-        SPI freq is set by serial_clock_rate and clock_prescale_rate.
-        The bit frequency will be:
+        SPI freq is set using either the freq_preset parameter or the 
+        combination of serial_clock_rate and clock_prescale_rate parameters.
+
+        When using serial_clock_rate & clock_prescale_rate parameters, the
+        resulting frequency will be:
             PCLK / (clock_prescale_rate * [serial_clock_rate+1]).
 
         Args:
             board -- The GreatFET board whose SPI bus we want to control.
             name -- The display name for the given SPI bus.
             buffer_size -- The size of the SPI receive buffer on the GreatFET.
+            freq_preset -- Set clock_prescale_rate and serial_clock_rate using
+                one of the frequency presets defined by SPIBus.FREQ
             clock_prescale_rate -- This even value between 2 and 254, by which
                 PCLK is divided to yield the prescaler output clock.
             serial_clock_rate -- The number of prescaler-output clocks per bit
@@ -41,6 +69,9 @@ class SPIBus(GreatFETPeripheral):
         # Create a list that will store all connected devices.
         self.devices = []
 
+        # Adjust frecuency parameters
+        if freq_preset != 0:
+            clock_prescale_rate, serial_clock_rate = freq_preset
         freq = serial_clock_rate << 8 | clock_prescale_rate
 
         # Set up the SPI bus for communications.


### PR DESCRIPTION
I'm not really into python, so not sure if there is any other better way around to define the frequency presets. Let me know if there is any other better approach and you want me to change the code.

I defined the spi frequencies inside `spi_bus.py` cause I'm assuming that only LPC43xx boards will be supported, otherwise these frequencies should be defined per board instead.