### PR TITLE
Remove warning about non-existent error on older versions of GCC

### DIFF
--- a/firmware/common/usb_type.h
+++ b/firmware/common/usb_type.h
@@ -215,6 +215,7 @@ typedef struct {
 
 	// Dword 5
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wpacked-not-aligned"
 	ehci_transfer_descriptor_t overlay;
 


### PR DESCRIPTION
Using `#pragma GCC diagnostic ignored "-Wpacked-not-aligned"` generates a warning on older versions of GCC as `Wpacked-not-aligned` wasn't a thing until newer versions. 