### PR TITLE
Firmware: track more oscillator/PLL timings

### DIFF
--- a/firmware/common/debug.c
+++ b/firmware/common/debug.c
@@ -335,7 +335,7 @@ void vprintk(int loglevel, char *fmt, va_list list)
 
     // TODO: support something like Linux's LOGLEVEL_CONTINUE
 
-    printf("[%8" PRIu32 "] ", get_time());
+    printf("[%12" PRIu32 "] ", get_time());
     vprintf(fmt, list);
 }
 

--- a/firmware/common/time.c
+++ b/firmware/common/time.c
@@ -14,10 +14,10 @@
  *
  * Currently must be called while on the faster clock speed.
  */
-void set_up_microsecond_timer(void)
+void set_up_microsecond_timer(uint32_t m4_clk_mhz)
 {
-	// Set up TIMER3 to count microseconds.
-    timer_set_prescaler(TIMER3, 203);
+    // Set up TIMER3 to count microseconds.
+    timer_set_prescaler(TIMER3, m4_clk_mhz - 1);
     timer_enable_counter(TIMER3);
 }
 

--- a/firmware/common/time.h
+++ b/firmware/common/time.h
@@ -15,9 +15,9 @@
  * Initialization function for the GreatFET microsecond timer, which is used
  * to track total seconds while the GreatFET is running.
  *
- * Currently must be called while on the faster clock speed.
+ * @param The frequency, in MHz, that the main M4 clock is running at.
  */
-void set_up_microsecond_timer(void);
+void set_up_microsecond_timer(uint32_t m4_clk_mhz);
 
 /**
  * @returns the total number of microseconds since this timer was initialized.

--- a/firmware/common/timers.h
+++ b/firmware/common/timers.h
@@ -1,0 +1,16 @@
+/*
+ * This file is part of GreatFET
+ */
+
+#ifndef LPC43XX_GF_TIMERS_H
+#define LPC43XX_GF_TIMERS_H
+
+#include <libopencm3/cm3/common.h>
+#include <libopencm3/lpc43xx/memorymap.h>
+
+
+#define ALARM_TIMER_BASE      0x40040000
+#define ALARM_TIMER_DOWNCOUNT MMIO32(ALARM_TIMER_BASE + 0)
+#define ALARM_TIMER_PRESET    MMIO32(ALARM_TIMER_BASE + 4)
+
+#endif


### PR DESCRIPTION
For hardware verification / diagnosis of slow startups, we now track the time it takes to start the main oscillator and to switch to each of its PLLs.

```
[           0] GreatFET started!
[           4] Bootstrapping the system clock off of the external 12MHz oscillator.
[        6131] External oscillator bringup complete (took 5844 uS).
[        6396] Switching the system clock to PLL1 at 48MHz.
[        8087] Clock switch complete (took 1470 uS).
[        8188] Switching the system clock to PLL1 at 204MHz.
[        9743] Clock switch complete (took 1499 uS).
[        9757] Configuring board pins...
[        9769] Board advertises an RTC. Bringing it up...
[      574424] RTC bringup complete (took 564642 uS).
```

