### PR TITLE
Fix flashing instructions for LPC Xplorer

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -102,7 +102,7 @@ Each of the currently supproted boards provides an accessible DFU bootloader:
    it on or while pressing and releasing the RESET button.
  * To start the LPC Xplorer in DFU mode, adjust the J4 switches so SW1-4
    are OFF, ON, OFF, and ON respectively, and then press the reset button. To
-   resume loading from flash, restore them to so SW1-4 are ON, OFF, OFF, OFF.
+   resume loading from flash, restore them to so SW1-4 are OFF, ON, ON, ON.
 
 Once the GreatFET is in DFU mode, run the following command from your firmware
 build tree:


### PR DESCRIPTION
The LPC4330 manual (https://www.nxp.com/docs/en/user-guide/UM10503.pdf) specifies SPI boot as the pins being set to 7 (in figure 16) but instructions incorrectly have all the switches backwards.

Closes #152