### PR TITLE
USB and communications fixes

### DIFF
--- a/libgreat/firmware/drivers/comms/comms_class.c
+++ b/libgreat/firmware/drivers/comms/comms_class.c
@@ -78,6 +78,7 @@ int comms_backend_submit_command(struct comm_backend_driver *backend,
 
 	// If the handling class has a command handler, use it!
 	if (handling_class->command_handler) {
+		pr_debug("dispatching a command via handler function for class %s\n", handling_class->name);
 		return handling_class->command_handler(trans);
 	}
 
@@ -94,6 +95,7 @@ int comms_backend_submit_command(struct comm_backend_driver *backend,
 	// with a NULL handler.
 	for (verb = handling_class->command_verbs; verb->handler; ++verb) {
 		if (verb->verb_number == trans->verb) {
+			pr_debug("dispatching command %s:%s()\n", handling_class->name, verb->name);
 			return verb->handler(trans);	
 		}
 	}

--- a/libgreat/firmware/drivers/comms/core.c
+++ b/libgreat/firmware/drivers/comms/core.c
@@ -131,4 +131,4 @@ static struct comms_verb core_verbs[] = {
 		{ .verb_number = 0x20, .handler = core_verb_request_reset },
 		{} // Sentinel
 };
-COMMS_DEFINE_SIMPLE_CLASS(core_api, CLASS_NUMBER_CORE, "Core API", core_verbs);
+COMMS_DEFINE_SIMPLE_CLASS(core_api, CLASS_NUMBER_CORE, "core", core_verbs);

--- a/libgreat/firmware/drivers/comms/utils.c
+++ b/libgreat/firmware/drivers/comms/utils.c
@@ -28,25 +28,25 @@
 		++target; \
 		trans->data_out_position = target; \
 		return target; \
-	} 
+	}
 
 #define COMMS_DEFINE_ARGUMENT_HANDLER(type) \
 	type comms_argument_parse_##type(struct command_transaction *trans) \
 	{ \
 		type *target = trans->data_in_position; \
 		type value = *target; \
-		uintptr_t position = (uintptr_t)trans->data_in_position - (uintptr_t)trans->data_in; \
 		\
-		if (position + sizeof(type) > trans->data_in_length) { \
+		if (sizeof(type) > trans->data_in_remaining) { \
 			pr_error("ERROR: command overread handling class %d / verb %d! \n", trans->class_number, trans->verb); \
 			return (type)0; \
 		} \
 		\
 		++target; \
+        trans->data_in_remaining -= sizeof(type); \
 		trans->data_in_position = target; \
 		\
 		return value; \
-	} 
+	}
 
 
 /** Quick response handling functions. */
@@ -75,7 +75,7 @@ void *comms_response_add_string(struct command_transaction *trans, char *respons
 
     // If we can't fit the relevant repsonse, fail out.
     if (length > length_left) {
-			pr_error("ERROR: command overwrite responding to class %d / verb %d! \n", trans->class_number, trans->verb); \
+			pr_error("ERROR: command overwrite responding to class %d / verb %d! \n", trans->class_number, trans->verb);
             return out_pointer;
     }
 
@@ -91,4 +91,61 @@ void *comms_response_add_string(struct command_transaction *trans, char *respons
 
     trans->data_out_position = response;
 	return response;
+}
+
+
+/**
+ * Grabs a chunk of up to max_length from the argument buffer.
+ *
+ * @param trans The associated transaction.
+ * @param max_length The maximum amount to read; or -1 for the remainder of the bfufer.
+ * @param out_length Out argument; accepts the actual amount read.
+ * @return A pointer to a buffer within the transaction that contains the relevant data.
+ */
+void *comms_argument_read_buffer(struct command_transaction *trans,
+        uint32_t max_length, uint32_t *out_length)
+{
+    void *start_pointer = trans->data_in_position;
+    uint8_t *end_pointer = start_pointer;
+    uint32_t length = trans->data_in_remaining;
+
+    // If our maximum length is less than the data available, truncate.
+    if (max_length < length)
+        length = max_length;
+
+    // Advance within the buffer accordingly.
+    end_pointer += length;
+    trans->data_in_remaining -= length;
+    trans->data_in_position = end_pointer;
+
+    *out_length = length;
+    return start_pointer;
+}
+
+
+/**
+ * Reserves a buffer of the provided size in the data output buffer.
+ *
+ * @param trans The associated transaction.
+ * @param size The amount of space to reserve.
+ *
+ * @return A pointer to the buffer that can be used for the relevant response,
+ *      or NULL if the relevant amount of space could not be reserved.
+ */
+void *comms_response_reserve_space(struct command_transaction *trans, uint32_t size)
+{
+    void *start_pointer = trans->data_out_position;
+    uint8_t *end_pointer = start_pointer;
+    uint32_t available_length = trans->data_out_max_length - trans->data_out_length;
+
+    if (size > available_length) {
+        pr_error("ERROR: command overwrite responding to class %d / verb %d! \n", trans->class_number, trans->verb); \
+        return NULL;
+    }
+
+    end_pointer += size;
+    trans->data_out_length += size;
+    trans->data_out_position = end_pointer;
+
+    return start_pointer;
 }

--- a/libgreat/firmware/drivers/comms/utils.c
+++ b/libgreat/firmware/drivers/comms/utils.c
@@ -42,7 +42,7 @@
 		} \
 		\
 		++target; \
-        trans->data_in_remaining -= sizeof(type); \
+		trans->data_in_remaining -= sizeof(type); \
 		trans->data_in_position = target; \
 		\
 		return value; \

--- a/libgreat/firmware/drivers/usb/comms_backend.c
+++ b/libgreat/firmware/drivers/usb/comms_backend.c
@@ -6,6 +6,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <debug.h>
 
 #include <drivers/comms.h>
 #include <drivers/comms_backend.h>
@@ -14,23 +15,25 @@
 #include <drivers/usb/lpc43xx/usb_standard_request.h>
 #include <drivers/usb/lpc43xx/usb_queue.h>
 
+#define LIBGREAT_REQUEST_CANCEL_VALUE (0xDEAD)
+
 struct comm_backend_driver usb_backend_driver = {
 	.name = "USB",
 };
-
-
-// FIXME: abstract the maximum size, here
-uint8_t usb_data_in_buffer[4096];
-uint8_t usb_data_out_buffer[4096];
 
 /** stores the currently active transaction; invalidated when
  * no transaction is currently active. */
 static struct command_transaction active_transaction;
 static bool transaction_underway = false;
 
+// FIXME: abstract the maximum size, here
+uint8_t usb_data_in_buffer[4096] ;
+uint8_t usb_data_out_buffer[4096];
+
+
 
 static usb_request_status_t libgreat_comms_vendor_request_out_handler(
-	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage) 
+	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
 {
 	int rc;
 	unsigned data_length;
@@ -39,6 +42,15 @@ static usb_request_status_t libgreat_comms_vendor_request_out_handler(
 	// and to the data that follows directly after.
 	struct libgreat_command_prelude *prelude = (void *)usb_data_in_buffer;
 	uint8_t *post_prelude_buffer = &usb_data_in_buffer[sizeof(*prelude)];
+
+	// If we've gotten out of sync, cancel the existing transaction and
+	// stall this request. This likely means the host misbehaved.
+	if ((stage != USB_TRANSFER_STAGE_STATUS) && transaction_underway) {
+		pr_error("comms error: host issued a new request while an active request is being handled "
+				"(handling %d:%d)! \n", active_transaction.class_number, active_transaction.verb);
+		transaction_underway = false;
+		return USB_REQUEST_STATUS_STALL;
+	}
 
 	// If we can't accomodate requests of the given size, stall.
 	if (endpoint->setup.length > sizeof(usb_data_in_buffer)) {
@@ -62,12 +74,7 @@ static usb_request_status_t libgreat_comms_vendor_request_out_handler(
 	}
 
 	// If we've just completed the data stage, we have data to work with!
-	// Excellent; let's issue the command itself.
 	if (stage == USB_TRANSFER_STAGE_DATA) {
-
-		// Acknowledge the transmission.
-		// TODO: validate the command submission, first?
-		usb_transfer_schedule_ack(endpoint->in);
 
 		// Populate the transaction details.
 		active_transaction.class_number = prelude->class_number;
@@ -76,9 +83,10 @@ static usb_request_status_t libgreat_comms_vendor_request_out_handler(
 		active_transaction.data_in_length = data_length;
 		active_transaction.data_out = usb_data_out_buffer;
 		active_transaction.data_out_max_length = sizeof(usb_data_out_buffer);
-        active_transaction.data_out_length = 0;
-        active_transaction.data_in_position = active_transaction.data_in;
-        active_transaction.data_out_position = active_transaction.data_out;
+		active_transaction.data_out_length = 0;
+		active_transaction.data_in_position = active_transaction.data_in;
+		active_transaction.data_out_position = active_transaction.data_out;
+		active_transaction.data_in_remaining = active_transaction.data_in_length;
 		transaction_underway = true;
 
 		// Submit the command to the backend for execution.
@@ -90,6 +98,10 @@ static usb_request_status_t libgreat_comms_vendor_request_out_handler(
 		if (rc) {
 			return USB_REQUEST_STATUS_STALL;
 		}
+		// Otherwise, ACK the transcation.
+		else {
+			usb_transfer_schedule_ack(endpoint->in);
+		}
 	}
 
 	return USB_REQUEST_STATUS_OK;
@@ -97,32 +109,53 @@ static usb_request_status_t libgreat_comms_vendor_request_out_handler(
 
 
 static usb_request_status_t libgreat_comms_vendor_request_in_handler(
-	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage) 
+	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
 {
-	if (!transaction_underway)
-		return USB_REQUEST_STATUS_STALL;
-
 	// If this is the setup stage of the transaction, schedule the data
 	// read itself.
 	if (stage == USB_TRANSFER_STAGE_SETUP) {
 
+		if (!transaction_underway) {
+			pr_error("comms error: requested a USB response when no communications were underway! (stage: %d)\n", stage);
+			return USB_REQUEST_STATUS_STALL;
+		}
+
 		// Transmit the amount of returned data, or the requested
 		// data; whichever is less.
-		unsigned data_length = active_transaction.data_out_length;
-		if (endpoint->setup.length < data_length)
+		uint32_t data_length = active_transaction.data_out_length;
+		if (endpoint->setup.length < data_length) {
 			data_length = endpoint->setup.length;
-
+		}
+		if (sizeof(usb_data_out_buffer) < data_length) {
+			data_length = sizeof(usb_data_out_buffer);
+		}
 		// Schedule the transfer itself.
 		usb_transfer_schedule_block(endpoint->in, usb_data_out_buffer,
 				data_length, NULL, NULL);
-		return USB_REQUEST_STATUS_OK;
 	}
 
-	// If this is the data stage of a transaction that's underway,
-	// mark it as complete.
+	// If this is the end of the DATA stage, queue an ACK for the status stage.
+	// and mark the transaction as dispatched.
 	if (stage == USB_TRANSFER_STAGE_DATA) {
-		usb_transfer_schedule_ack(endpoint->out);
 		transaction_underway = false;
+		usb_transfer_schedule_ack(endpoint->out);
+	}
+
+	return USB_REQUEST_STATUS_OK;
+}
+
+/**
+ * Handler for special cancellation requests, which abort execution of an
+ * existing command. These allow us to fail gracefully rather than being
+ * confused as to where we are in the command.
+ */
+static usb_request_status_t libgreat_comms_vendor_request_cancel_handler(
+	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
+{
+	if (stage == USB_TRANSFER_STAGE_SETUP) {
+		pr_debug("usb comms: aborting active command at host's request\n");
+		transaction_underway = false;
+		usb_transfer_schedule_ack(endpoint->in);
 	}
 
 	return USB_REQUEST_STATUS_OK;
@@ -134,9 +167,14 @@ static usb_request_status_t libgreat_comms_vendor_request_in_handler(
  * communicating via a libgreat backend.
  */
 usb_request_status_t libgreat_comms_vendor_request_handler(
-	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage) 
+	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
 {
 	bool is_in_request;
+
+	// If this is a cancel request, cancel the active request.
+	if (endpoint->setup.value == LIBGREAT_REQUEST_CANCEL_VALUE) {
+		return libgreat_comms_vendor_request_cancel_handler(endpoint, stage);
+	}
 
 	// If this is an IN request, we're being asked for the response
 	// to a previous query. Handle that accordingly.
@@ -147,4 +185,5 @@ usb_request_status_t libgreat_comms_vendor_request_handler(
 	} else {
 		return libgreat_comms_vendor_request_out_handler(endpoint, stage);
 	}
+
 }

--- a/libgreat/firmware/drivers/usb/lpc43xx/usb_queue.c
+++ b/libgreat/firmware/drivers/usb/lpc43xx/usb_queue.c
@@ -8,6 +8,8 @@
 #include <assert.h>
 #include <string.h>
 
+#include <debug.h>
+
 #include <libopencm3/cm3/cortex.h>
 #include <libopencm3/cm3/sync.h>
 
@@ -19,192 +21,220 @@ usb_queue_t* endpoint_queues[NUM_USB_CONTROLLERS][12] = {};
 #define USB_ENDPOINT_INDEX(endpoint_address) (((endpoint_address & 0xF) * 2) + ((endpoint_address >> 7) & 1))
 
 static usb_queue_t* endpoint_queue(
-        const usb_endpoint_t* const endpoint
+		const usb_endpoint_t* const endpoint
 ) {
-        uint32_t index = USB_ENDPOINT_INDEX(endpoint->address);
-        if (endpoint_queues[endpoint->device->controller][index] == NULL) while (1);
-        return endpoint_queues[endpoint->device->controller][index];
+		uint32_t index = USB_ENDPOINT_INDEX(endpoint->address);
+		if (endpoint_queues[endpoint->device->controller][index] == NULL) while (1);
+		return endpoint_queues[endpoint->device->controller][index];
 }
 
 void usb_queue_init(
-        usb_queue_t* const queue
+		usb_queue_t* const queue
 ) {
-        uint32_t index = USB_ENDPOINT_INDEX(queue->endpoint->address);
-        if (endpoint_queues[queue->endpoint->device->controller][index] != NULL) while (1);
-        endpoint_queues[queue->endpoint->device->controller][index] = queue;
+		uint32_t index = USB_ENDPOINT_INDEX(queue->endpoint->address);
+		if (endpoint_queues[queue->endpoint->device->controller][index] != NULL) while (1);
+		endpoint_queues[queue->endpoint->device->controller][index] = queue;
 
-        usb_transfer_t* t = queue->free_transfers;
-        for (unsigned int i=0; i < queue->pool_size - 1; i++, t++) {
-                t->next = t+1;
-                t->queue = queue;
-        }
-        t->next = NULL;
-        t->queue = queue;
+		usb_transfer_t* t = queue->free_transfers;
+		for (unsigned int i=0; i < queue->pool_size - 1; i++, t++) {
+				t->next = t+1;
+				t->queue = queue;
+		}
+		t->next = NULL;
+		t->queue = queue;
 }
 
 /* Allocate a transfer */
 static usb_transfer_t* allocate_transfer(
-        usb_queue_t* const queue
+		usb_queue_t* const queue
 ) {
-        bool aborted;
-        usb_transfer_t* transfer;
-        if (queue->free_transfers == NULL)
-                return NULL;
+		bool aborted;
+		usb_transfer_t* transfer;
+		if (queue->free_transfers == NULL)
+				return NULL;
 
-        do {
-                transfer = (void *) __ldrex((uint32_t *) &queue->free_transfers);
-                aborted = __strex((uint32_t) transfer->next, (uint32_t *) &queue->free_transfers);
-        } while (aborted);
-        transfer->next = NULL;
-        return transfer;
+		do {
+				transfer = (void *) __ldrex((uint32_t *) &queue->free_transfers);
+				aborted = __strex((uint32_t) transfer->next, (uint32_t *) &queue->free_transfers);
+		} while (aborted);
+		transfer->next = NULL;
+		return transfer;
 }
 
 /* Place a transfer in the free list */
 static void free_transfer(usb_transfer_t* const transfer)
 {
-        usb_queue_t* const queue = transfer->queue;
-        bool aborted;
-        do {
-                transfer->next = (void *) __ldrex((uint32_t *) &queue->free_transfers);
-                aborted = __strex((uint32_t) transfer, (uint32_t *) &queue->free_transfers);
-        } while (aborted);
+		usb_queue_t* const queue = transfer->queue;
+		bool aborted;
+		do {
+				transfer->next = (void *) __ldrex((uint32_t *) &queue->free_transfers);
+				aborted = __strex((uint32_t) transfer, (uint32_t *) &queue->free_transfers);
+		} while (aborted);
 }
 
 /* Add a transfer to the end of an endpoint's queue. Returns the old
  * tail or NULL is the queue was empty
  */
 static usb_transfer_t* endpoint_queue_transfer(
-        usb_transfer_t* const transfer
+		usb_transfer_t* const transfer
 ) {
-        usb_queue_t* const queue = transfer->queue;
-        transfer->next = NULL;
-        if (queue->active != NULL) {
-            usb_transfer_t* t = queue->active;
-            while (t->next != NULL) t = t->next;
-            t->next = transfer;
-            return t;
-        } else {
-            queue->active = transfer;
-            return NULL;
-        }
-}
-                
-static void usb_queue_flush_queue(usb_queue_t* const queue)
-{
-        cm_disable_interrupts();
-        while (queue->active) {
-                usb_transfer_t* transfer = queue->active;
-                queue->active = transfer->next;
-                free_transfer(transfer);
-        }
-        cm_enable_interrupts();
-}
-
-void usb_queue_flush_endpoint(const usb_endpoint_t* const endpoint)
-{
-        usb_queue_flush_queue(endpoint_queue(endpoint));
+		usb_queue_t* const queue = transfer->queue;
+		transfer->next = NULL;
+		if (queue->active != NULL) {
+			usb_transfer_t* t = queue->active;
+			while (t->next != NULL) t = t->next;
+			t->next = transfer;
+			return t;
+		} else {
+			queue->active = transfer;
+			return NULL;
+		}
 }
 
 int usb_transfer_schedule(
 	const usb_endpoint_t* const endpoint,
 	void* const data,
 	const uint32_t maximum_length,
-        const transfer_completion_cb completion_cb,
-        void* const user_data
+		const transfer_completion_cb completion_cb,
+		void* const user_data
 ) {
-        usb_queue_t* const queue = endpoint_queue(endpoint);
-        usb_transfer_t* const transfer = allocate_transfer(queue);
-        if (transfer == NULL) return -1;
-        usb_transfer_descriptor_t* const td = &transfer->td;
+		usb_queue_t* const queue = endpoint_queue(endpoint);
+		usb_transfer_t* const transfer = allocate_transfer(queue);
+		if (transfer == NULL) return -1;
+		usb_transfer_descriptor_t* const td = &transfer->td;
 
 	// Configure the transfer descriptor
-        td->next_dtd_pointer = USB_TD_NEXT_DTD_POINTER_TERMINATE;
+		td->next_dtd_pointer = USB_TD_NEXT_DTD_POINTER_TERMINATE;
 	td->total_bytes =
 		  USB_TD_DTD_TOKEN_TOTAL_BYTES(maximum_length)
 		| USB_TD_DTD_TOKEN_IOC
 		| USB_TD_DTD_TOKEN_MULTO(0)
-		| USB_TD_DTD_TOKEN_STATUS_ACTIVE
-		;
+		| USB_TD_DTD_TOKEN_STATUS_ACTIVE ;
 	td->buffer_pointer_page[0] =  (uint32_t)data;
 	td->buffer_pointer_page[1] = ((uint32_t)data + 0x1000) & 0xfffff000;
 	td->buffer_pointer_page[2] = ((uint32_t)data + 0x2000) & 0xfffff000;
 	td->buffer_pointer_page[3] = ((uint32_t)data + 0x3000) & 0xfffff000;
 	td->buffer_pointer_page[4] = ((uint32_t)data + 0x4000) & 0xfffff000;
 
-        // Fill in transfer fields
-        transfer->maximum_length = maximum_length;
-        transfer->completion_cb = completion_cb;
-        transfer->user_data = user_data;
+		// Fill in transfer fields
+		transfer->maximum_length = maximum_length;
+		transfer->completion_cb = completion_cb;
+		transfer->user_data = user_data;
 
-        cm_disable_interrupts();
-        usb_transfer_t* tail = endpoint_queue_transfer(transfer);
-        if (tail == NULL) {
-                // The queue is currently empty, we need to re-prime
-                usb_endpoint_schedule_wait(queue->endpoint, &transfer->td);
-        } else {
-                // The queue is currently running, try to append
-                usb_endpoint_schedule_append(queue->endpoint, &tail->td, &transfer->td);
-        }
-        cm_enable_interrupts();
-        return 0;
+		cm_disable_interrupts();
+		usb_transfer_t* tail = endpoint_queue_transfer(transfer);
+		if (tail == NULL) {
+				// The queue is currently empty, we need to re-prime
+				usb_endpoint_schedule_wait(queue->endpoint, &transfer->td);
+		} else {
+				// The queue is currently running, try to append
+				usb_endpoint_schedule_append(queue->endpoint, &tail->td, &transfer->td);
+		}
+		cm_enable_interrupts();
+		return 0;
 }
 	
 int usb_transfer_schedule_block(
 	const usb_endpoint_t* const endpoint,
 	void* const data,
 	const uint32_t maximum_length,
-        const transfer_completion_cb completion_cb,
-        void* const user_data
+		const transfer_completion_cb completion_cb,
+		void* const user_data
 ) {
-        int ret;
-        do {
-                ret = usb_transfer_schedule(endpoint, data, maximum_length,
-                                            completion_cb, user_data);
-        } while (ret == -1);
-        return 0;
+		int ret;
+		do {
+				ret = usb_transfer_schedule(endpoint, data, maximum_length,
+											completion_cb, user_data);
+		} while (ret == -1);
+		return 0;
 }
 
 int usb_transfer_schedule_ack(
 	const usb_endpoint_t* const endpoint
 ) {
-        return usb_transfer_schedule_block(endpoint, 0, 0, NULL, NULL);
+		return usb_transfer_schedule_block(endpoint, 0, 0, NULL, NULL);
 }
+
+
 
 /* Called when an endpoint might have completed a transfer */
+static void usb_queue_clean_up_transfers(usb_endpoint_t* const endpoint, bool include_active)
+{
+		usb_queue_t* const queue = endpoint_queue(endpoint);
+		if (queue == NULL) while(1); // Uh oh
+		usb_transfer_t* transfer = queue->active;
+
+		while (transfer != NULL) {
+				uint8_t status = transfer->td.total_bytes;
+				bool aborting = false;
+
+				bool td_is_active = (status & USB_TD_DTD_TOKEN_STATUS_ACTIVE);
+
+				// Check for failures
+				if (status & USB_TD_DTD_TOKEN_STATUS_HALTED) {
+					pr_error("usb error:transaction reports halted status! aborting.");
+					aborting = true;
+				}
+				if (status & USB_TD_DTD_TOKEN_STATUS_BUFFER_ERROR) {
+					pr_error("usb error:transaction reports buffer error! aborting.");
+					aborting = true;
+				}
+				if (status & USB_TD_DTD_TOKEN_STATUS_TRANSACTION_ERROR) {
+					pr_error("usb error:transaction reports transaction error! aborting.");
+					aborting = true;
+				}
+
+				// TODO: check for timeout, or NAK count, or etc?
+
+				// If we're aborting due to an error, the TD is effetively non-active.
+				if (aborting) {
+					td_is_active = false;
+				}
+
+				// If this in active, non-error'd transaction, ignore it.
+				if (td_is_active) {
+					if (!include_active && td_is_active) {
+						break;
+					} else {
+						// TODO: abstract me
+						int number = endpoint->address & 0x7f;
+						const char *direction = endpoint->address & 0x80 ? "IN" : "OUT";
+
+						pr_info("usb stack: discarding an active transcation on EP%d:%s!\n", number, direction);
+						pr_info("usb stack: (discard was likely due to overriding SETUP or STALL)\n");
+					}
+				}
+
+				// FIXME: add in an error callback, which should do the below instead of us
+				// in the event of an error!
+
+				// Advance the head. We need to do this before invoking the completion
+				// callback as it might attempt to schedule a new transfer
+				queue->active = transfer->next;
+				usb_transfer_t* next = transfer->next;
+
+				// Invoke completion callback
+				unsigned int total_bytes = (transfer->td.total_bytes & USB_TD_DTD_TOKEN_TOTAL_BYTES_MASK) >> USB_TD_DTD_TOKEN_TOTAL_BYTES_SHIFT;
+				unsigned int transferred = transfer->maximum_length - total_bytes;
+				if (transfer->completion_cb)
+						transfer->completion_cb(transfer->user_data, transferred);
+
+				// Advance head and free transfer
+				free_transfer(transfer);
+				transfer = next;
+		}
+}
+
+
 void usb_queue_transfer_complete(usb_endpoint_t* const endpoint)
 {
-        usb_queue_t* const queue = endpoint_queue(endpoint);
-        if (queue == NULL) while(1); // Uh oh
-        usb_transfer_t* transfer = queue->active;
-
-        while (transfer != NULL) {
-                uint8_t status = transfer->td.total_bytes;
-
-                // Check for failures
-                if (   status & USB_TD_DTD_TOKEN_STATUS_HALTED
-                    || status & USB_TD_DTD_TOKEN_STATUS_BUFFER_ERROR
-                    || status & USB_TD_DTD_TOKEN_STATUS_TRANSACTION_ERROR) {
-                        // TODO: Uh oh, do something useful here
-                        while (1);
-                }
-
-                // Still not finished
-                if (status & USB_TD_DTD_TOKEN_STATUS_ACTIVE) 
-                        break;
-
-                // Advance the head. We need to do this before invoking the completion
-                // callback as it might attempt to schedule a new transfer
-                queue->active = transfer->next;
-                usb_transfer_t* next = transfer->next;
-
-                // Invoke completion callback
-                unsigned int total_bytes = (transfer->td.total_bytes & USB_TD_DTD_TOKEN_TOTAL_BYTES_MASK) >> USB_TD_DTD_TOKEN_TOTAL_BYTES_SHIFT;
-                unsigned int transferred = transfer->maximum_length - total_bytes;
-                if (transfer->completion_cb)
-                        transfer->completion_cb(transfer->user_data, transferred);
-
-                // Advance head and free transfer
-                free_transfer(transfer);
-                transfer = next;
-        }
+	usb_queue_clean_up_transfers(endpoint, false);
 }
+
+void usb_queue_flush_endpoint(const usb_endpoint_t* const endpoint)
+{
+		cm_disable_interrupts();
+		usb_queue_clean_up_transfers(endpoint, true);
+		cm_enable_interrupts();
+}
+

--- a/libgreat/firmware/include/drivers/comms.h
+++ b/libgreat/firmware/include/drivers/comms.h
@@ -65,6 +65,7 @@ struct command_transaction {
      */
     void *data_in_position;
     void *data_out_position;
+    uint32_t data_in_remaining;
 };
 
 
@@ -280,5 +281,27 @@ COMMS_DECLARE_ARGUMENT_HANDLER(int32_t);
  * Adds a string to the communications response.
  */
 void *comms_response_add_string(struct command_transaction *trans, char *response);
+
+/**
+ * Reserves a buffer of the provided size in the data output buffer.
+ *
+ * @param trans The associated transaction.
+ * @param size The amount of space to reserve.
+ *
+ * @return A pointer to the buffer that can be used for the relevant response,
+ *      or NULL if the relevant amount of space could not be reserved.
+ */
+void *comms_response_reserve_space(struct command_transaction *trans, uint32_t size);
+
+/**
+ * Grabs a chunk of up to max_length from the argument buffer.
+ *
+ * @param trans The associated transaction.
+ * @param max_length The maximum amount to read.
+ * @param out_length Out argument; accepts the actual amount read.
+ * @return A pointer to a buffer within the transaction that contains the relevant data.
+ */
+void *comms_argument_read_buffer(struct command_transaction *trans,
+        uint32_t max_length, uint32_t *out_length);
 
 #endif

--- a/libgreat/firmware/include/drivers/usb/lpc43xx/usb_queue.h
+++ b/libgreat/firmware/include/drivers/usb/lpc43xx/usb_queue.h
@@ -59,6 +59,15 @@ int usb_transfer_schedule_block(
         void* const user_data
 );
 
+int usb_transfer_schedule_wait(
+	const usb_endpoint_t* const endpoint,
+	void* const data,
+	const uint32_t maximum_length,
+	const transfer_completion_cb completion_cb,
+	void* const user_data,
+	uint32_t timeout
+);
+
 int usb_transfer_schedule_ack(
 	const usb_endpoint_t* const endpoint
 );

--- a/libgreat/firmware/include/drivers/usb/lpc43xx/usb_queue.h
+++ b/libgreat/firmware/include/drivers/usb/lpc43xx/usb_queue.h
@@ -71,4 +71,8 @@ void usb_queue_transfer_complete(
         usb_endpoint_t* const endpoint
 );
 
+
+void usb_queue_invalidate_transfers(
+        usb_endpoint_t* const endpoint
+);
 #endif//__USB_QUEUE_H__


### PR DESCRIPTION
This suite of commits provides the foundation for a number of changes to come over the next few days. Primarily, it should dramatically increase the stability of USB communications -- allowing communications to resume even in the event of an error that 'breaks the state' of the USB connection.

This is especially nice, as we can e.g. run `greatfet dmesg` even after a USB request handler fails to execute properly or times out. 