### PR TITLE
Pad serial numbers to 32 character for passing to pyUSB

### DIFF
--- a/libgreat/host/pygreat/comms_backends/usb.py
+++ b/libgreat/host/pygreat/comms_backends/usb.py
@@ -76,6 +76,11 @@ class USBCommsBackend(CommsBackend):
         to a more specific board by serial number.
         """
 
+        # Zero pad serial numbers to 32 characters to match those
+        # provided by the USB descriptors
+        if 'serial_number' in device_identifiers and len(device_identifiers['serial_number']) < 32:
+            device_identifiers['serial_number'] = device_identifiers['serial_number'].zfill(32)
+
         # Connect to the first available device.
         try:
             self.device = usb.core.find(**device_identifiers)


### PR DESCRIPTION
This fixes #186 by padding serial numbers before passing them to pyUSB.  It does not pad them for other comms backends (of which we have none right now).