### PR TITLE
Return part ID as ints, matchesi the way we handle serials

### DIFF
--- a/libgreat/host/pygreat/board.py
+++ b/libgreat/host/pygreat/board.py
@@ -380,11 +380,6 @@ class GreatBoard(object):
 
 def _to_hex_string(byte_array):
     """Convert a byte array to a hex string."""
-    # Python2 compatibility
-    try:
-        byte_array = future.builtins.bytes(byte_array)
-    except ValueError:
-        byte_array = list(byte_array)
 
     hex_generator = ('{:02x}'.format(x) for x in byte_array)
     return ''.join(hex_generator)

--- a/libgreat/host/pygreat/classes/core.py
+++ b/libgreat/host/pygreat/classes/core.py
@@ -33,7 +33,7 @@ class CoreAPI(CommsClass):
             name="read_version_string", out_parameter_names=["version"], doc="Fetches the board's version.")
 
     # RPC that reads the part ID
-    read_part_id = command_rpc(verb_number=0x2, out_format="<8s", name="read_part_id", out_parameter_names=["part_id"])
+    read_part_id = command_rpc(verb_number=0x2, out_format="<2I", name="read_part_id", out_parameter_names=["part_id"])
     read_part_id.__doc__ = \
         """Fetches the part ID used on the board.
         


### PR DESCRIPTION
It seems sensible to return the part ID the same way that we return the serial number, so that's what this does.  It removes the python 2 workaround in `_to_hex_string()`

Fixes #185 by removing the need for `future.builtins`

There may be unforeseen consequences if this, so I'm asking @ktemkin for review.