### PR TITLE
glitchkit: try to handle USB failures in a more friendly way

### DIFF
--- a/host/greatfet/commands/greatfet_shell.py
+++ b/host/greatfet/commands/greatfet_shell.py
@@ -4,6 +4,12 @@
 
 from __future__ import print_function
 
+import inspect
+import errno
+import sys
+import re
+
+from greatfet import GreatFET
 from greatfet.utils import GreatFETArgumentParser
 
 import IPython
@@ -20,8 +26,19 @@ def main():
     args = parser.parse_args()
     gf = parser.find_specified_device()
 
+    # Handle any inline execution.
     if args.code:
-        print(repr(eval(args.code)))
+
+        # Replace any ;'s with newlines, so we can execute more than one statement.
+        code = re.sub(";\s*", "\n", args.code)
+        lines = code.split("\n")
+
+        # And execute the code.
+        for line in lines:
+            result = repr(eval(line))
+
+        # Print the last result and return.
+        print(result)
         sys.exit(0)
 
 

--- a/host/greatfet/glitchkit/usb.py
+++ b/host/greatfet/glitchkit/usb.py
@@ -66,14 +66,23 @@ class GlitchKitUSB(GlitchKitModule):
         """ Determines if this GreatFET supports GlitchKit via USB. """
         return board.supports_api("glitchkit_usb")
 
-    @staticmethod
-    def _decode_reg(reg):
-        status_hex = codecs.encode(reg[::-1], 'hex')
-        return int(status_hex, 16)
+
+    def configure_future_requests(self, continue_despite_errors, disable_vbus_afterwards):
+        """ Configure future requests made by this GlitchKit module.
+
+        Arguments:
+            continue_despite_errors -- True iff stimuli should continue even
+                if errors occur.
+            disable_vbus_afterwards -- If set, VBUS will be disconnected after
+                a given USB request.
+        """
+        self.api.configure_requests(continue_despite_errors, disable_vbus_afterwards)
 
 
     @staticmethod
     def _split(value):
+        # TODO: get rid of this
+
         value_high  = value >> 8
         value_low = value & 0xFF
         return [value_low, value_high]
@@ -82,12 +91,13 @@ class GlitchKitUSB(GlitchKitModule):
     @staticmethod
     def build_request_type(is_in, type, recipient):
 
+        # TODO: FIXME: clean up consts
         request_type = 0
 
         if is_in:
             request_type |= (1 << 7)
 
-        request_type |= (type << 5 )
+        request_type |= (type << 5)
         request_type |= (recipient)
 
         return request_type
@@ -100,6 +110,7 @@ class GlitchKitUSB(GlitchKitModule):
         #       uint16_t index;
         #       uint16_t length;
 
+        # TODO: replace me with a call to struct.pack?
         setup_request = [self.build_request_type(is_in, request_type, recipient), request]
         setup_request.extend(self._split(value))
         setup_request.extend(self._split(index))

--- a/libgreat/firmware/drivers/comms/utils.c
+++ b/libgreat/firmware/drivers/comms/utils.c
@@ -67,6 +67,7 @@ COMMS_DEFINE_HELPERS(uint32_t);
 COMMS_DEFINE_HELPERS(int8_t);
 COMMS_DEFINE_HELPERS(int16_t);
 COMMS_DEFINE_HELPERS(int32_t);
+COMMS_DEFINE_HELPERS(_Bool);
 
 void *comms_response_add_string(struct command_transaction *trans, char const *const response)
 {

--- a/libgreat/firmware/drivers/usb/lpc43xx/usb_queue_host.c
+++ b/libgreat/firmware/drivers/usb/lpc43xx/usb_queue_host.c
@@ -569,11 +569,11 @@ int usb_host_transfer(usb_peripheral_t *host, ehci_queue_head_t *qh, const usb_t
 	}
 
 	// Return an error code if the transaction errored out.
-	if (transfer_state.stalled) {
-		return EPIPE;
-	}
 	if (transfer_state.error) {
 		return EIO;
+	}
+	if (transfer_state.stalled) {
+		return EPIPE;
 	}
 
 	// If we got here, everything went well!

--- a/libgreat/firmware/include/drivers/comms.h
+++ b/libgreat/firmware/include/drivers/comms.h
@@ -361,6 +361,19 @@ COMMS_DECLARE_HELPERS(uint32_t);
 COMMS_DECLARE_HELPERS(int8_t);
 COMMS_DECLARE_HELPERS(int16_t);
 COMMS_DECLARE_HELPERS(int32_t);
+COMMS_DECLARE_HELPERS(_Bool);
+
+/** Alias for _Bool, per the C standard. */
+static inline void *comms_response_add_bool(struct command_transaction *trans, bool response)
+{
+	return comms_response_add__Bool(trans, response);
+}
+
+/** Alias for _Bool, per the C standard. */
+static inline bool comms_argument_parse_bool(struct command_transaction *trans)
+{
+	return comms_argument_parse__Bool(trans);
+}
 
 
 /**


### PR DESCRIPTION
This addresses most of @mossmann's commentary in #92:

- Failures don't block the host GreatFET.
- Added an option to disable VBUS afterwards.
- Further improvements to system stability to enhance the user's experience.~