### PR TITLE
i2c: scan/read/write improvements

### DIFF
--- a/firmware/common/greatfet_core.c
+++ b/firmware/common/greatfet_core.c
@@ -62,14 +62,16 @@ i2c_bus_t i2c0 = {
 	.obj = (void*)I2C0_BASE,
 	.start = i2c_lpc_start,
 	.stop = i2c_lpc_stop,
-	.transfer = i2c_lpc_transfer,
+	.read = i2c_lpc_read,
+	.write = i2c_lpc_write
 };
 
 i2c_bus_t i2c1 = {
 	.obj = (void*)I2C1_BASE,
 	.start = i2c_lpc_start,
 	.stop = i2c_lpc_stop,
-	.transfer = i2c_lpc_transfer,
+	.read = i2c_lpc_read,
+	.write = i2c_lpc_write
 };
 
 const ssp_config_t ssp_config_spi = {

--- a/firmware/common/i2c_bus.c
+++ b/firmware/common/i2c_bus.c
@@ -12,11 +12,18 @@ void i2c_bus_stop(i2c_bus_t* const bus) {
 	bus->stop(bus);
 }
 
-uint8_t i2c_bus_transfer(
+uint8_t i2c_bus_read(
 	i2c_bus_t* const bus,
 	const uint_fast8_t slave_address,
-	const uint8_t* const tx, const size_t tx_count,
 	uint8_t* const rx, const size_t rx_count
 ) {
-	return bus->transfer(bus, slave_address, tx, tx_count, rx, rx_count);
+	return bus->read(bus, slave_address, rx, rx_count);
+}
+
+uint8_t i2c_bus_write(
+	i2c_bus_t* const bus,
+	const uint_fast8_t slave_address,
+	const uint8_t* const tx, const size_t tx_count
+) {
+	return bus->write(bus, slave_address, tx, tx_count);
 }

--- a/firmware/common/i2c_bus.h
+++ b/firmware/common/i2c_bus.h
@@ -15,21 +15,29 @@ struct i2c_bus_t {
 	void* const obj;
 	void (*start)(i2c_bus_t* const bus, const uint16_t config);
 	void (*stop)(i2c_bus_t* const bus);
-	uint8_t (*transfer)(
+	uint8_t (*read)(
 		i2c_bus_t* const bus,
 		const uint_fast8_t slave_address,
-		const uint8_t* const tx, const size_t tx_count,
 		uint8_t* const rx, const size_t rx_count
+	);
+	uint8_t (*write)(
+		i2c_bus_t* const bus,
+		const uint_fast8_t slave_address,
+		const uint8_t* const tx, const size_t tx_count
 	);
 };
 
 void i2c_bus_start(i2c_bus_t* const bus, const uint16_t config);
 void i2c_bus_stop(i2c_bus_t* const bus);
-uint8_t i2c_bus_transfer(
+uint8_t i2c_bus_read(
 	i2c_bus_t* const bus,
 	const uint_fast8_t slave_address,
-	const uint8_t* const tx, const size_t tx_count,
 	uint8_t* const rx, const size_t rx_count
+);
+uint8_t i2c_bus_write(
+	i2c_bus_t* const bus,
+	const uint_fast8_t slave_address,
+	const uint8_t* const tx, const size_t tx_count
 );
 
 #endif/*__I2C_BUS_H__*/

--- a/firmware/common/i2c_lpc.h
+++ b/firmware/common/i2c_lpc.h
@@ -12,10 +12,12 @@
 
 void i2c_lpc_start(i2c_bus_t* const bus, uint16_t duty_cycle_count);
 void i2c_lpc_stop(i2c_bus_t* const bus);
-uint8_t i2c_lpc_transfer(i2c_bus_t* const bus,
+uint8_t i2c_lpc_read(i2c_bus_t* const bus,
 	const uint_fast8_t slave_address,
-	const uint8_t* const data_tx, const size_t count_tx,
 	uint8_t* const data_rx, const size_t count_rx
 );
-
+uint8_t i2c_lpc_write(i2c_bus_t* const bus,
+	const uint_fast8_t slave_address,
+	const uint8_t* const data_tx, const size_t count_tx
+);
 #endif/*__I2C_LPC_H__*/

--- a/firmware/greatfet_usb/classes/i2c.c
+++ b/firmware/greatfet_usb/classes/i2c.c
@@ -13,7 +13,8 @@
 #define CLASS_NUMBER_SELF (0x108)
 
 static uint16_t duty_cycle_count;
-static uint8_t status;
+static uint8_t read_status;
+static uint8_t write_status;
 
 static int i2c_verb_start(struct command_transaction *trans)
 {
@@ -31,26 +32,67 @@ static int i2c_verb_start(struct command_transaction *trans)
 static int i2c_verb_stop()
 {
 	i2c_bus_stop(&i2c0);
-
 	return 0;	
 }
 
-static int i2c_verb_xfer(struct command_transaction *trans)
+static int i2c_verb_read(struct command_transaction *trans)
 {
-	uint32_t tx_length;
 	uint16_t address 		= comms_argument_parse_uint16_t(trans);
 	uint16_t rx_length 		= comms_argument_parse_uint16_t(trans);
-	uint8_t *data_to_write 	= comms_argument_read_buffer(trans, -1, &tx_length);
 	uint8_t *i2c_rx_buffer 	= comms_response_reserve_space(trans, rx_length);
 	// TODO: data validation
 
 	if (!comms_transaction_okay(trans)) {
         return EBADMSG;
     }
+	read_status = i2c_bus_read(&i2c0, address, i2c_rx_buffer, rx_length);
+	comms_response_add_uint8_t(trans, read_status);
 
-	status = i2c_bus_transfer(&i2c0, address & 0xff, data_to_write, tx_length, 
-					 i2c_rx_buffer, rx_length);
-	comms_response_add_uint8_t(trans, status);
+	return 0;
+}
+
+static int i2c_verb_write(struct command_transaction *trans)
+{
+	uint32_t tx_length;
+	uint16_t address 		= comms_argument_parse_uint16_t(trans);
+	uint8_t *data_to_write 	= comms_argument_read_buffer(trans, -1, &tx_length);
+	// TODO: data validation
+
+	if (!comms_transaction_okay(trans)) {
+        return EBADMSG;
+    }
+	write_status = i2c_bus_write(&i2c0, address, data_to_write, tx_length);
+	comms_response_add_uint8_t(trans, write_status);
+
+	return 0;
+}
+
+static int i2c_verb_scan(struct command_transaction *trans)
+{
+	uint8_t *write_status_buffer = comms_response_reserve_space(trans, 16);
+	uint8_t *read_status_buffer = comms_response_reserve_space(trans, 16);
+	uint8_t address;
+
+	if (!comms_transaction_okay(trans)) {
+        return EBADMSG;
+    }
+
+	for (address = 0; address < 16; address++) {
+		write_status_buffer[address] = 0;
+		read_status_buffer[address] = 0;
+	}
+
+	for (address = 0; address < 128; address++) {
+		write_status = i2c_bus_write(&i2c0, address, NULL, 0);
+		if (write_status == 0x18) {
+			write_status_buffer[address >> 3] |= 1 << (address & 0x07);
+		}
+
+		read_status = i2c_bus_read(&i2c0, address, NULL, 0);
+		if (read_status == 0x40) {
+			read_status_buffer[address >> 3] |= 1 << (address & 0x07);
+		}
+	}
 
 	return 0;
 }
@@ -67,10 +109,18 @@ static struct comms_verb _verbs[] = {
 			.in_signature = "", .out_signature = "",
 			.in_param_names = "",
 			.doc = "Transmit a stop bit to an I2C device" },
-		{ .name = "xfer", .handler = i2c_verb_xfer,
-			.in_signature = "<HH*X", .out_signature = "<*B",
-			.in_param_names = "value, index, data", .out_param_names = "response, status",
-			.doc = "Transmits data over the I2C bus and responds accordingly" },
+		{ .name = "read", .handler = i2c_verb_read,
+			.in_signature = "<HH", .out_signature = "<*B",
+			.in_param_names = "value, index", .out_param_names = "response, status",
+			.doc = "Reads from the I2C bus and responds accordingly" },
+		{ .name = "write", .handler = i2c_verb_write,
+			.in_signature = "<H*X", .out_signature = "<B",
+			.in_param_names = "value, index, data", .out_param_names = "status",
+			.doc = "Writes to the I2C bus and responds accordingly" },
+		{ .name = "scan", .handler = i2c_verb_scan,
+			.in_signature = "", .out_signature = "<*B",
+			.in_param_names = "value, index, data", .out_param_names = "states",
+			.doc = "Scans all valid I2C addresses for attached devices" },
 		{} // Sentinel
 };
 COMMS_DEFINE_SIMPLE_CLASS(i2c, CLASS_NUMBER_SELF, "i2c", _verbs,

--- a/host/greatfet/boards/one.py
+++ b/host/greatfet/boards/one.py
@@ -4,8 +4,6 @@
 
 from ..board import GreatFETBoard
 
-from ..peripherals.gpio import GPIO
-from ..peripherals.led import LED
 from ..peripherals.i2c_bus import I2CBus
 from ..peripherals.spi_bus import SPIBus
 from ..peripherals.firmware import DeviceFirmwareManager
@@ -153,8 +151,11 @@ class GreatFETOne(GreatFETBoard):
         # XXX disable perpiherals as we develop libgreat
         # return
 
-        self.i2c_busses = [ I2CBus(self, 'I2C0') ]
+        # self.i2c_busses = [ I2CBus(self, 'I2C0') ]
         self.spi_busses = [ SPIBus(self, 'SPI1') ]
+
+        if self.supports_api('i2c'):
+            self.i2c_busses = [ I2CBus(self, 'I2C0') ]
 
         # Create an easy-to-use alias for the primary busses, for rapid
         # hacking/experimentation.

--- a/host/greatfet/peripherals/i2c_device.py
+++ b/host/greatfet/peripherals/i2c_device.py
@@ -37,9 +37,9 @@ class I2CDevice(GreatFETPeripheral):
         self.bus.attach_device(self)
 
 
-    def transmit(self, data, receive_length=0):
+    def transmit(self, data, receive_length):
         """
-            Sends data over the I2C bus, and optionally recieves
+            Sends data over the I2C bus, and recieves
             data in response.
 
             Args:
@@ -48,3 +48,24 @@ class I2CDevice(GreatFETPeripheral):
                         to read the provided amount of data, in bytes.
         """
         return self.bus.transmit(self.address, data, receive_length)
+
+
+    def read(self, receive_length=0):
+        """
+            Reads data from the I2C bus.
+
+            Args:
+                receive_length -- The I2C controller will attempt
+                        to read the provided amount of data, in bytes.
+        """
+        return self.bus.read(self.address, receive_length)
+
+
+    def write(self, data):
+        """
+            Sends data over the I2C bus.
+
+            Args:
+                data -- The data to be sent to the given device.
+        """
+        return self.bus.write(self.address, data)


### PR DESCRIPTION
i2c: move scan to firmware, fix 7 vs 8-bit address issues, split transfer into separate read/write functions, implement table output for scan