### PR TITLE
Isochronous and usb stall fixes

### DIFF
--- a/libgreat/firmware/drivers/usb/lpc43xx/usb.c
+++ b/libgreat/firmware/drivers/usb/lpc43xx/usb.c
@@ -805,7 +805,8 @@ void usb_endpoint_init_without_descriptor(
 	// descriptor.
 	usb_queue_head_t* const qh = usb_queue_head(endpoint->address, endpoint->device);
 	qh->capabilities
-		= USB_QH_CAPABILITIES_MULT(0)
+	    // MULT has to be 1..3 for isochronous transfer, we assume 1 should be sufficient
+		= ((transfer_type != USB_TRANSFER_TYPE_ISOCHRONOUS) ? USB_QH_CAPABILITIES_MULT(0) : USB_QH_CAPABILITIES_MULT(1)) 
 		| USB_QH_CAPABILITIES_MPL(max_packet_size)
 		| ((transfer_type == USB_TRANSFER_TYPE_CONTROL) ? USB_QH_CAPABILITIES_IOS : 0)
 		| ((transfer_type == USB_TRANSFER_TYPE_CONTROL) ? 0 : USB_QH_CAPABILITIES_ZLT);


### PR DESCRIPTION
This commit fixes two usb implementation bugs, mainly discovered while using Facedancer on Greatfet One.

The first bug is that if any endpoint is defined as isochronous, on setting configuration, the device just hangs due to usb protocol errors.

The second bug, most severe, will lead to a sig fault due to pointer deference (transfer is null, thus transfer->next will go to nowhere). It might be that this isn't the bug initially causing this, but at least fixing the dereference makes Facedancer work on iPhone device emulation for now and will prevent the greatfet to become fully unresponsable.

This is the debugger message :

Program received signal SIGSEGV, Segmentation fault.
usb_transfer_schedule (endpoint=, data=data@entry=0x10085e60 <total_received_data>,
maximum_length=maximum_length@entry=512,
completion_cb=completion_cb@entry=0x2165 <store_transfer_count_callback>,
user_data=user_data@entry=0x10085e70 <usb_host_write_status>)
at /home/bjk/greatfet/firmware/common/usb_queue.c:116
116 usb_transfer_t* const transfer = allocate_transfer(queue);

it gets triggered if a clear request or set configuration request has to be handled. See https://github.com/bkerler/Facedancer, try "python3 facedancer-emu -device iPhone" to trigger this bug.
