### PR TITLE
host: py2 compat: switch to relative imports in greatfet.utils

### DIFF
--- a/host/greatfet/utils.py
+++ b/host/greatfet/utils.py
@@ -12,8 +12,8 @@ import time
 import errno
 import argparse
 
-from greatfet import GreatFET
-from greatfet.boards.flash_stub import GreatFETFlashStub
+from . import GreatFET
+from .boards.flash_stub import GreatFETFlashStub
 
 from pygreat.errors import DeviceNotFoundError
 


### PR DESCRIPTION
This should fix #226, which occurs due to python2's overly permissive
PATH-scheme.