### PR TITLE
Host: setup.py: fix `long_description` to use README.md instead of README

### DIFF
--- a/host/setup.py
+++ b/host/setup.py
@@ -57,7 +57,7 @@ setup(
     tests_require=[''],
     install_requires=['pyusb', install_req, 'pygreat', 'future'],
     description='Python library for hardware hacking with the GreatFET',
-    long_description=read('README'),
+    long_description=read('README.md'),
     packages=find_packages(),
     include_package_data=True,
     platforms='any',


### PR DESCRIPTION
`python setup.py install` was failing with `FileNotFoundError` due to this.