### PR TITLE
Return once the child process *ends* (windows bug fix)

### DIFF
--- a/host/greatfet/commands/gf.py
+++ b/host/greatfet/commands/gf.py
@@ -194,7 +194,7 @@ def main():
     arguments = [binary_name] + argv[2:]
 
     # Pass control entirely to the subcommand.
-    sys.exit(os.execv(binary, arguments))
+    sys.exit(os.spawnv(os.P_WAIT, binary, arguments))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
On Windows, execv returns when the child process *starts*. The intended behavior is it to return when the process *ends*.
Issue described here: https://bugs.python.org/msg198599

**I have not tested that this change has the correct behavior on linux**

Before this fix on Windows, the `greatfet` command would return, then run the subcommand in the  background:
![image](https://user-images.githubusercontent.com/1299430/58254964-f47dbe00-7d39-11e9-8e1c-672670afd3f8.png)
After this change on Windows, `greatfet` doesn't return until the subcommand is complete (matches linux behavior):
![image](https://user-images.githubusercontent.com/1299430/58255196-766de700-7d3a-11e9-9022-12b01ef3cc8d.png)

