### PR TITLE
build: fix #254 and clean up the build system a bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ addons:
     - arm-none-eabi-gcc
     - dfu-util
 before_install:
-- openssl aes-256-cbc -K $encrypted_3584182e1d21_key -iv $encrypted_3584182e1d21_iv
-  -in id_deploy.enc -out id_deploy -d
 - pip install PyYAML
 before_script:
 - export CFLAGS="-Wall -Wextra"

--- a/firmware/cmake/build_config.cmake
+++ b/firmware/cmake/build_config.cmake
@@ -13,9 +13,6 @@ if (NOT(VERSION_LOCAL_SUFFIX STREQUAL ""))
     set(VERSION "${VERSION}-${VERSION_SUFFIX}")
 endif()
 
-# FIXME: handle versioning correctly
-set(VERSION_STRING "git-${VERSION}")
-
 # Set the maximum depth of a debug backtrace.
 set(DEBUG_MAX_BACKTRACE_DEPTH 25 CACHE STRING "The maximum depth of a backtrace to report, if backtracing is enabled.")
 configuration_depends_on_features(DEBUG_MAX_BACKTRACE_DEPTH BACKTRACE)


### PR DESCRIPTION
- remove duplication in the build system code
- rename VERSION to RELEASE_VERSION to differentiate versions that
  will be tagged from local or intermediate versions
- fix a stray "git" suffix in release / tagged builds