### PR TITLE
firmware: Initial implementation of swra124 class

### DIFF
--- a/firmware/common/CMakeLists.txt
+++ b/firmware/common/CMakeLists.txt
@@ -32,6 +32,7 @@ add_greatfet_library_if_necessary(libgreatfet OBJECT
     ${PATH_GREATFET_FIRMWARE_COMMON}/jtag.c
     ${PATH_GREATFET_FIRMWARE_COMMON}/jtag_msp430.c
     ${PATH_GREATFET_FIRMWARE_COMMON}/printf.c
+    ${PATH_GREATFET_FIRMWARE_COMMON}/swra124.c
 )
 
 # FIXME: move debug into its own module so we don't  have to manually code this

--- a/firmware/common/swra124.c
+++ b/firmware/common/swra124.c
@@ -1,0 +1,131 @@
+#include "swra124.h"
+
+#include <gpio.h>
+#include <gpio_lpc.h>
+#include <greatfet_core.h>
+#include <libopencm3/lpc43xx/scu.h>
+#include <pins.h>
+
+static struct gpio_t swra124_reset = GPIO(0, 10);
+static struct gpio_t swra124_clock = GPIO(0, 11);
+static struct gpio_t swra124_data = GPIO(0, 15);
+
+void swra124_setup() {
+  scu_pinmux(SCU_PINMUX_GPIO0_10, SCU_GPIO_FAST | SCU_CONF_FUNCTION0);
+  scu_pinmux(SCU_PINMUX_GPIO0_11, SCU_GPIO_FAST | SCU_CONF_FUNCTION0);
+  scu_pinmux(SCU_PINMUX_GPIO0_15, SCU_GPIO_FAST | SCU_CONF_FUNCTION0);
+
+  gpio_write(&swra124_reset, 1);
+  gpio_write(&swra124_clock, 0);
+  gpio_write(&swra124_data, 0);
+
+  gpio_output(&swra124_reset);
+  gpio_output(&swra124_clock);
+  gpio_input(&swra124_data);
+}
+
+void swra124_debug_init() {
+  struct {
+    struct gpio_t *gpio;
+    uint8_t value;
+  } steps[] = {
+    {.gpio = &swra124_reset, .value = 0},
+    {.gpio = &swra124_clock, .value = 1},
+    {.gpio = &swra124_clock, .value = 0},
+    {.gpio = &swra124_clock, .value = 1},
+    {.gpio = &swra124_clock, .value = 0},
+    {.gpio = &swra124_reset, .value = 1},
+    {.gpio = NULL},
+  };
+  for (int i = 0; steps[i].gpio; i++) {
+    gpio_write(steps[i].gpio, steps[i].value);
+    delay_us(1);
+  }
+}
+
+void swra124_write_byte(const uint8_t v) {
+  gpio_output(&swra124_data);
+  for (int i = 0; i < 8; i++) {
+    gpio_write(&swra124_data, (v >> (7 - i)) & 0x01);
+    delay_us(1);
+    gpio_write(&swra124_clock, 1);
+    delay_us(1);
+    gpio_write(&swra124_clock, 0);
+    delay_us(1);
+  }
+}
+
+void swra124_write(const uint8_t *data, const size_t size) {
+  for (size_t i = 0; i < size; i++) {
+    swra124_write_byte(data[i]);
+  }
+}
+
+uint8_t swra124_read() {
+  uint8_t result = 0;
+  gpio_input(&swra124_data);
+  for (int i = 0; i < 8; i++) {
+    gpio_write(&swra124_clock, 1);
+    delay_us(1);
+    result = (result << 1) | gpio_read(&swra124_data);
+    delay_us(1);
+    gpio_write(&swra124_clock, 0);
+    delay_us(1);
+  }
+  return result;
+}
+
+void swra124_chip_erase() {
+  uint8_t command[] = {0x14};
+  swra124_write(command, 1);
+  swra124_read();
+}
+
+void swra124_write_config(const uint8_t config) {
+  uint8_t command[] = {0x1d, config};
+  swra124_write(command, 2);
+  swra124_read();
+}
+
+uint8_t swra124_read_status() {
+  uint8_t command[] = {0x34};
+  swra124_write(command, 1);
+  return swra124_read();
+}
+
+uint16_t swra124_get_chip_id() {
+  uint8_t command[] = {0x68};
+  swra124_write(command, 1);
+  return (swra124_read() << 8) | swra124_read();
+}
+
+void swra124_halt() {
+  uint8_t command[] = {0x44};
+  swra124_write(command, 1);
+  swra124_read();
+}
+
+void swra124_resume() {
+  uint8_t command[] = {0x4c};
+  swra124_write(command, 1);
+  swra124_read();
+}
+
+uint8_t swra124_debug_instr(const uint8_t *instr, const size_t size) {
+  uint8_t command[] = {0x54 | (size & 0x03)};
+  swra124_write(command, 1);
+  swra124_write(instr, size);
+  return swra124_read();
+}
+
+void swra124_step_instr() {
+  uint8_t command[] = {0x5c};
+  swra124_write(command, 1);
+  swra124_read();
+}
+
+uint16_t swra124_get_pc() {
+  uint8_t command[] = {0x28};
+  swra124_write(command, 1);
+  return (swra124_read() << 8) | swra124_read();
+}

--- a/firmware/common/swra124.h
+++ b/firmware/common/swra124.h
@@ -1,0 +1,19 @@
+#ifndef __SWRA124_H__
+#define __SWRA124_H__
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define SWRA124_MAX_INSTR_SIZE 4
+
+void swra124_setup();
+void swra124_debug_init();
+uint8_t swra124_read_status();
+uint16_t swra124_get_chip_id();
+void swra124_halt();
+void swra124_resume();
+uint8_t swra124_debug_instr(const uint8_t *instr, const size_t size);
+void swra124_step_instr();
+uint16_t swra124_get_pc();
+
+#endif

--- a/firmware/greatfet_usb/classes/swra124.c
+++ b/firmware/greatfet_usb/classes/swra124.c
@@ -1,0 +1,138 @@
+// The swra124 class implements the debug transport for debugging and
+// programming cc111x, cc243x, and cc251x 8051-based integrated MCU and
+// RF transceivers from Texas Instruments (Chipcon).
+
+#include <debug.h>
+#include <drivers/comms.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <swra124.h>
+
+#define CLASS_NUMBER_SELF (0x114)
+
+static int swra124_verb_setup() {
+  swra124_setup();
+  return 0;
+}
+
+static int swra124_verb_debug_init() {
+  swra124_debug_init();
+  return 0;
+}
+
+static int swra124_verb_read_status(struct command_transaction *trans) {
+  comms_response_add_uint8_t(trans, swra124_read_status());
+  return 0;
+}
+
+static int swra124_verb_get_chip_id(struct command_transaction *trans) {
+  comms_response_add_uint16_t(trans, swra124_get_chip_id());
+  return 0;
+}
+
+static int swra124_verb_halt() {
+  swra124_halt();
+  return 0;
+}
+
+static int swra124_verb_resume() {
+  swra124_resume();
+  return 0;
+}
+
+static int swra124_verb_debug_instr(struct command_transaction *trans) {
+  size_t size = 0;
+  uint8_t instr[SWRA124_MAX_INSTR_SIZE];
+  while (comms_argument_data_remaining(trans) && size < SWRA124_MAX_INSTR_SIZE) {
+    instr[size++] = comms_argument_parse_uint8_t(trans);
+  }
+  if (comms_argument_data_remaining(trans) || size == 0) {
+    pr_error("swra124: invalid instruction");
+    return EINVAL;
+  }
+  comms_response_add_uint8_t(trans, swra124_debug_instr(instr, size));
+  return 0;
+}
+
+static int swra124_verb_step_instr() {
+  swra124_step_instr();
+  return 0;
+}
+
+static int swra124_verb_get_pc(struct command_transaction *trans) {
+  comms_response_add_uint16_t(trans, swra124_get_pc());
+  return 0;
+}
+
+static struct comms_verb swra124_verbs[] = {
+  {
+    .name = "setup",
+    .handler = swra124_verb_setup,
+    .in_signature = "",
+    .out_signature = "",
+    .doc = "initialize pin mapping for debugging",
+  },
+  {
+    .name = "debug_init",
+    .handler = swra124_verb_debug_init,
+    .in_signature = "",
+    .out_signature = "",
+    .doc = "reset target into debugging mode",
+  },
+  {
+    .name = "read_status",
+    .handler = swra124_verb_read_status,
+    .in_signature = "",
+    .out_signature = "B",
+    .out_param_names = "status",
+    .doc = "read status byte from target",
+  },
+  {
+    .name = "get_chip_id",
+    .handler = swra124_verb_get_chip_id,
+    .in_signature = "",
+    .out_signature = "H",
+    .out_param_names = "chip_id",
+    .doc = "read chip ID from target",
+  },
+  {
+    .name = "halt",
+    .handler = swra124_verb_halt,
+    .in_signature = "",
+    .out_signature = "",
+    .doc = "halt target execution",
+  },
+  {
+    .name = "resume",
+    .handler = swra124_verb_resume,
+    .in_signature = "",
+    .out_signature = "",
+    .doc = "resume target execution",
+  },
+  {
+    .name = "debug_instr",
+    .handler = swra124_verb_debug_instr,
+    .in_signature = "<*B",
+    .out_signature = "B",
+    .out_param_names = "a_reg",
+    .doc = "execute instruction on target",
+  },
+  {
+    .name = "step_instr",
+    .handler = swra124_verb_step_instr,
+    .in_signature = "",
+    .out_signature = "",
+    .doc = "single-step target",
+  },
+  {
+    .name = "get_pc",
+    .handler = swra124_verb_get_pc,
+    .in_signature = "",
+    .out_signature = "H",
+    .out_param_names = "pc",
+    .doc = "get program counter from target",
+  },
+  {},
+};
+COMMS_DEFINE_SIMPLE_CLASS(swra124, CLASS_NUMBER_SELF, "swra124", swra124_verbs,
+    "cc1110/cc243x/cc251x debug transport");


### PR DESCRIPTION
The swra124 class implements the debugging/programming transport for
CC1110, CC1111, CC2431, CC2510, and CC2511 integrated 8051 + RF
microcontrollers.

The name comes from the document containing the specification.