### PR TITLE
fix bug in greatfet_i2c.py --scan

### DIFF
--- a/host/greatfet/commands/greatfet_i2c.py
+++ b/host/greatfet/commands/greatfet_i2c.py
@@ -93,7 +93,7 @@ def scan(device, log_function):
                     addr_info[address][1].append(mode)
                 else:
                     addr_info[address] = (response, [mode])
-            else:
+            elif address not in addr_info:
                 addr_info[address] = ((None, None), [None])
     # list output
     print("Working I2C address(es): (Address, RW bit, frequency)")
@@ -122,4 +122,3 @@ def scan(device, log_function):
 
 if __name__ == '__main__':
     main()
-    


### PR DESCRIPTION
Negative results at higher clock speeds overwrote positive results at lower clock speeds.