### PR TITLE
Switch to mossmann's libopencm3 fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "firmware/libopencm3"]
 	path = firmware/libopencm3
-	url = https://github.com/dominicgs/libopencm3
+	url = https://github.com/mossmann/libopencm3
 [submodule "libgreat"]
 	path = libgreat
 	url = https://github.com/greatscottgadgets/libgreat


### PR DESCRIPTION
I merged dominicgs's fork into mine before making this change.  Additionally my fork has a fix for compilation on gentoo.

After this PR is merged, folks who have previously checked out the submodule will need to do:
```
git submodule sync
git submodule update
```