### PR TITLE
Don't check using "is not" with a literal

### DIFF
--- a/host/greatfet/interfaces/adc.py
+++ b/host/greatfet/interfaces/adc.py
@@ -14,7 +14,7 @@ class ADC(GreatFETInterface):
     def __init__(self, board, board_pin='J2_P5', adc_num=0, significant_bits=10):
 
         # Sanity check:
-        if adc_num is not 0 and adc_num is not 1:
+        if adc_num != 0 and adc_num != 1:
             raise ValueError("Specified an unavailable ADC! (Valid values are 0 and 1).")
 
         self.board = board


### PR DESCRIPTION
```
$ greatfet_firmware -w firmware/build/greatfet_usb/greatfet_usb.bin
/Users/chris/Projects/greatfet/host/greatfet/interfaces/adc.py:17: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if adc_num is not 0 and adc_num is not 1:
/Users/chris/Projects/greatfet/host/greatfet/interfaces/adc.py:17: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if adc_num is not 0 and adc_num is not 1:
Trying to find a GreatFET device...
GreatFET One found. (Serial number: 000057cc67e634bc7857)
Writing data to SPI flash...

                                                                                
Write complete!
Reset not specified; new firmware will not start until next reset.
```