### PR TITLE
Avoid warning due to 'is not' usage with literal.

### DIFF
--- a/host/greatfet/interfaces/adc.py
+++ b/host/greatfet/interfaces/adc.py
@@ -14,7 +14,7 @@ class ADC(GreatFETInterface):
     def __init__(self, board, board_pin='J2_P5', adc_num=0, significant_bits=10):
 
         # Sanity check:
-        if adc_num is not 0 and adc_num is not 1:
+        if adc_num not in (0, 1):
             raise ValueError("Specified an unavailable ADC! (Valid values are 0 and 1).")
 
         self.board = board


### PR DESCRIPTION
Without, the following is logged with Python 3.8.0:

```
/code/src/greatfet/host/greatfet/interfaces/adc.py:17: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if adc_num is not 0 and adc_num is not 1:
/code/src/greatfet/host/greatfet/interfaces/adc.py:17: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if adc_num is not 0 and adc_num is not 1:
```
