### PR TITLE
Fix spi interface shortname

### DIFF
--- a/host/greatfet/interfaces/spi_bus.py
+++ b/host/greatfet/interfaces/spi_bus.py
@@ -15,7 +15,7 @@ class SPIBus(PirateCompatibleInterface):
 
 
     # Short name for this type of interface.
-    INTERFACE_SHORT_NAME = "i2c"
+    INTERFACE_SHORT_NAME = "spi"
 
     class FREQ():
         """


### PR DESCRIPTION
Noticed the SPI shortname is i2c when looking through python help()