### PR TITLE
host: uart command: fix python KeyError when parity argument not specified

### DIFF
--- a/host/greatfet/commands/greatfet_uart.py
+++ b/host/greatfet/commands/greatfet_uart.py
@@ -93,7 +93,7 @@ def main():
     parser.add_argument('baud', nargs='?', type=from_eng_notation, default=115200, help="Baud rate; in symbols/second. Defaults to 115200.")
     parser.add_argument('-d', '--data',  type=int, default=8, help="The number of data bits per frame.")
     parser.add_argument('-S', '--stop',  type=int, default=1, help="The number of stop bits per frame.")
-    parser.add_argument('-P', '--parity', choices=parity_modes, default=0, help="The type of parity to use.")
+    parser.add_argument('-P', '--parity', choices=parity_modes, default='none', help="The type of parity to use.")
     parser.add_argument('-E', '--echo', action='store_true', help="If provided, local echo will be enabled.")
     parser.add_argument('-N', '--no-newline-translation', action='store_false', dest='tr_newlines',
         help="Provide this option to disable newline translation.")


### PR DESCRIPTION
Changes the default value of the "parity" argument to a valid key value.
The default value of `0` causes Python to throw a KeyError when the uart parameters are set with `device.uart.update_parameters()`. Changing the default to `'none'` resolves this and allows the uart command to be used without specifying the parity.