### PR TITLE
Documentation: Fix appearance of tables in documentation PDF

### DIFF
--- a/docs/source/libgreat_verb_signatures.rst
+++ b/docs/source/libgreat_verb_signatures.rst
@@ -6,31 +6,31 @@ LibGreat Verb Signatures
 
 .. code-block :: sh
 
-	{    
-	    // The name of the verb. These are typically named like C function names.
-	    .name = "sum_and_difference", 
-	    
-	    // The handler function for the given verb. This is the verb definition we
-	    // provided above.
-	    .handler = example_verb_sum_and_difference,
+  {    
+      // The name of the verb. These are typically named like C function names.
+      .name = "sum_and_difference", 
+      
+      // The handler function for the given verb. This is the verb definition we
+      // provided above.
+      .handler = example_verb_sum_and_difference,
 
-	    // A short piece of documentation for the verb.
-	    .doc = "Computes the sum and difference of two ints.",
+      // A short piece of documentation for the verb.
+      .doc = "Computes the sum and difference of two ints.",
 
-	    // The signature for the verb's arguments. This roughly matches python's
-	    // struct.pack format; see the wiki documentation for more information.
-	    .in_signature = "<II",
+      // The signature for the verb's arguments. This roughly matches python's
+      // struct.pack format; see the wiki documentation for more information.
+      .in_signature = "<II",
 
-	    // The signature for the verb's return values. This roughly matches python's
-	    // struct.pack format; see the wiki documentation for more information.
-	    .out_signature = "<II",
+      // The signature for the verb's return values. This roughly matches python's
+      // struct.pack format; see the wiki documentation for more information.
+      .out_signature = "<II",
 
-	    // The names of the arguments to the verb.
-	    .in_param_names = "a, b",
+      // The names of the arguments to the verb.
+      .in_param_names = "a, b",
 
-	    // The names of the return values for the verb.
-	    .out_param_names = "sum, difference"
-	},
+      // The names of the return values for the verb.
+      .out_param_names = "sum, difference"
+  },
 
 This meta-data can include machine-parseable descriptions of each verb's signatures in the form of a short, machine-readable string. These strings include a description of the arguments to the function (the in-signature) and of the function's multiple return values (the out-signature); and effectively describe the data formats sent to and from the device during execution of a verb.
 
@@ -43,169 +43,149 @@ Describing Verb Signatures
 
 Verb signatures are provided in a format that's heavily inspired by `Python's struct module <https://docs.python.org/2/library/struct.html>`__ -- in fact, the formats are mostly identical. To provide some additional flexibility, we support a few additional format characters. The standard and added format characters are described below:
 
-.. list-table :: 
-  :header-rows: 1
-  :widths: 1 1 1 1 1 1 1
+.. list-table:: Verb Signatures
+   :widths: 10 7 11 10 33 29  
+   :header-rows: 1
 
-  * - Format
-    - Bytes
-    - C-Type
-    - Python Type
-    - libgreat parse function
-    - libgreat response function
-    - notes
-  * - x
-    - 1
-    - none
-    - none
-    - ``comms_argument_read_buffer(trans, 1, NULL)``
-    - ``comms_argument_read_buffer(trans, 1, NULL)``
-    - (1)
-  * - c 	
-    - 1 	
-    - char 	
-    - string of length 1 	
-    - ``comms_argument_parse_uint8_t``
-    - ``comms_response_add_uin8t_t``
-    - 
-  * - b 	
-    - 1 	
-    - ``int8_t``
-    - integer 	
-    - ``comms_argument_parse_int8_t``
-    - ``comms_response_add_int8_t``
-    - 
-  * - B 	
-    - 1 	
-    - ``uint8_t``
-    - integer 	
-    - ``comms_argument_parse_uint8_t``
-    - ``comms_response_add_uint8_t``
-    - 
-  * - ? 	
-    - 1 	
-    - ``bool`` / ``_Bool`` 	
-    - integer 	
-    - ``comms_argument_parse_bool``
-    - ``comms_response_add_bool``
-    - 
-  * - h 	
-    - 2 	
-    - ``int16_t``
-    - integer 	
-    - ``comms_argument_parse_int16_t``
-    - ``comms_response_add_int16_t``
-    - 
-  * - H 	
-    - 2 	
-    - ``uint16_t``
-    - integer 	
-    - ``comms_argument_parse_uint16_t``
-    - ``comms_response_add_uint16_t``
-    - 
-  * - i 	
-    - 4 	
-    - ``int32_t``
-    - integer 	
-    - ``comms_argument_parse_int32_t``
-    - ``comms_response_add_int32_t``
-    - 
-  * - I 	
-    - 4 	
-    - ``uint32_t``
-    - integer 	
-    - ``comms_argument_parse_uint32_t``
-    - ``comms_response_add_uint32_t``
-    - 
-  * - l 	
-    - 4 	
-    - ``int32_t``
-    - integer 	
-    - ``comms_argument_parse_int32_t``
-    - ``comms_response_add_int32_t``
-    - 
-  * - L 	
-    - 4 	
-    - ``uint32_t``
-    - integer 	
-    - ``comms_argument_parse_uint32_t``
-    - ``comms_response_add_uint32_t``
-    - 
-  * - q 	
-    - 8 	
-    - ``int64_t``
-    - integer 	
-    - ``comms_argument_parse_int64_t``
-    - ``comms_response_add_int64_t``
-    - 
-  * - Q 	
-    - 8 	
-    - ``uint64_t``
-    - integer 	
-    - ``comms_argument_parse_uint64_t``
-    - ``comms_response_add_uint64_t``
-    - 
-  * - f 	
-    - 4 	
-    - ``float``
-    - float 	
-    - ``comms_argument_parse_float``
-    - ``comms_response_add_float``
-    - 
-  * - d 	
-    - 8 	
-    - ``double`` 	
-    - float 	
-    - ``comms_argument_parse_double``
-    - ``comms_response_add_double``
-    - 
-  * - s
-    -  		
-    - ``char[]``
-    - string 	
-    - ``comms_argument_read_buffer``
-    - ``comms_response_add_raw``
-    - (2)(3)(6)
-  * - p 
-    - 		
-    - ``char[]``
-    - string 	
-    - ``comms_argument_parse_uint8_t`` / ``comms_argument_read_buffer``
-    - ``comms_response_add_uint8_t`` / ``comms_response_add_raw``
-    - (2)(6)
-  * - S 
-    - 		
-    - ``char[]``
-    - string 	
-    - ``comms_argument_read_string``
-    - ``comms_response_add_string``
-    - `(4)`
-  * - X 		
-    - 
-    - ``uint8_t``
-    - bytes of length 1 	
-    - ``comms_argument_read_string``
-    - ``comms_response_add_string``
-    - (3)(5)(6)
+   * - Format
+     - Bytes
+     - C-Type
+     - Python Type
+     - libgreat parse function
+     - libgreat response function
+   * - x (1)
+     - 1
+     - none
+     - none
+     - comms_argument_read_buffer( trans, 1, NULL )
+     - comms_argument_read_buffer( trans, 1, NULL )
+   * - c  
+     - 1  
+     - char   
+     - string of length 1   
+     - comms_argument_parse_uint8_t
+     - comms_response_add_uint8_t
+   * - b  
+     - 1  
+     - int8_t
+     - integer  
+     - comms_argument_parse_int8_t
+     - comms_response_add_int8_t
+   * - B  
+     - 1  
+     - uint8_t
+     - integer  
+     - comms_argument_parse_uint8_t
+     - comms_response_add_uint8_t
+   * - ?  
+     - 1  
+     - bool / _Bool   
+     - integer  
+     - comms_argument_parse_bool
+     - comms_response_add_bool
+   * - h  
+     - 2  
+     - int16_t
+     - integer  
+     - comms_argument_parse_int16_t
+     - comms_response_add_int16_t
+   * - H  
+     - 2  
+     - uint16_t
+     - integer  
+     - comms_argument_parse_uint16_t
+     - comms_response_add_uint16_t
+   * - i  
+     - 4  
+     - int32_t
+     - integer  
+     - comms_argument_parse_int32_t
+     - comms_response_add_int32_t
+   * - I  
+     - 4  
+     - uint32_t
+     - integer  
+     - comms_argument_parse_uint32_t
+     - comms_response_add_uint32_t
+   * - l  
+     - 4  
+     - int32_t
+     - integer  
+     - comms_argument_parse_int32_t
+     - comms_response_add_int32_t
+   * - L  
+     - 4  
+     - uint32_t
+     - integer  
+     - comms_argument_parse_uint32_t
+     - comms_response_add_uint32_t
+   * - q  
+     - 8  
+     - int64_t
+     - integer  
+     - comms_argument_parse_int64_t
+     - comms_response_add_int64_t
+   * - Q  
+     - 8  
+     - uint64_t
+     - integer  
+     - comms_argument_parse_uint64_t
+     - comms_response_add_uint64_t
+   * - f  
+     - 4  
+     - float
+     - float  
+     - comms_argument_parse_float
+     - comms_response_add_float
+   * - d  
+     - 8  
+     - double   
+     - float  
+     - comms_argument_parse_double
+     - comms_response_add_double
+   * - s (2) (3) (6)
+     -      
+     - char[]
+     - string   
+     - comms_argument_read_buffer
+     - comms_response_add_raw
+   * - p (2) (6)
+     -    
+     - char[]
+     - string   
+     - comms_argument_parse_uint8_t / comms_argument_read_buffer
+     - comms_response_add_uint8_t / comms_response_add_raw
+   * - S (4)
+     -    
+     - char[]
+     - string   
+     - comms_argument_read_string
+     - comms_response_add_string
+   * - X (3) (5) (6)    
+     - 
+     - uint8_t
+     - bytes of length 1  
+     - comms_argument_read_string
+     - comms_response_add_string
 
 
-.. list-table :: 
+.. list-table:: 
   :header-rows: 1
   :widths: 1 2
 
-  * - note number 	
+  * - note number   
     - description
-  * - (1) 	
+  * - (1)   
     - null padding byte; rarely used
-  * - (2) 	
+  * - (2)   
     - see python docs
-  * - (3) 	
+  * - (3)   
     - typically used with a numeric prefix
-  * - (4) 	
+  * - (4)   
     - encodes a null-terminated string
-  * - (5) 	
+  * - (5)   
     - encodes raw bytes; repeated elements are merged into a single entry
-  * - (6) 	
+  * - (6)   
     - numeric prefixes behave differently; see below
 
 ``libgreat`` data is always of standard size, and *always* little-endian. **Accordingly, every non-empty method signature must begin with a '<'.** Exceptions are made for methods that expect no arguments or return no values, which can provide an empty string.
@@ -244,13 +224,13 @@ A handful of format specifiers interpret numeric prefixes as *element lengths*, 
   :header-rows: 1
   :widths: 1 3
 
-  * - type 	
+  * - type  
     - interpretation
-  * - s 	
+  * - s   
     - the specified element represents a string of N characters, where N is the length specifier
-  * - p 	
+  * - p   
     - the specified element represents a pascal string of maximum length N, where N is the length specifier
-  * - X 	
+  * - X   
     - the specified element represents a string of N bytes, where N is the length specifier
 
 For the ``s`` and ``X`` specifiers, a length specifier of ``*`` indicates that the relevant string can be expected to take up all of the remaining data. Note that the format ``S`` does accepts a *repeat specifier* and **not** a *length specifier*, so the string ``32S`` denotes 32 null-terminated strings.
@@ -274,53 +254,53 @@ It may help to consider an example RPC with the following meta-data:
 
 .. code-block:: sh
 
-	{ .name = "sum_polar", .handler = example_verb_sum_polar, .in_signature = "<*(II)",
-   		.out_signature = "<II", .in_param_names = "magnitudes_and_angles", .out_param_names = "sum_magnitude, sum_angle",
-   		.doc = "Sums together a collection of polar coordinates." },	
+  { .name = "sum_polar", .handler = example_verb_sum_polar, .in_signature = "<*(II)",
+      .out_signature = "<II", .in_param_names = "magnitudes_and_angles", .out_param_names = "sum_magnitude, sum_angle",
+      .doc = "Sums together a collection of polar coordinates." },  
 
 The method's in-signature, ``<*(II)``, demonstrates that the method expects any number of *two-element pairs*, which each contain a pair of integers. Accordingly, we might call it as follows:
 
 .. code-block:: sh
 
-	# Assuming the RPC is available as gf.apis.example.sum_polar:
-	magnitude, angle = gf.apis.example.sum_polar((1, 2,), (3, 4),)
+  # Assuming the RPC is available as gf.apis.example.sum_polar:
+  magnitude, angle = gf.apis.example.sum_polar((1, 2,), (3, 4),)
 
 Each argument will be intepreted as a pair of 32-bit integers; so the resultant data stream will wind up looking like:
 
 .. code-block:: sh
 
-	<uint32_t '1'><uint32_t '2'><uint32_t '3'><uint32_t '4'>
+  <uint32_t '1'><uint32_t '2'><uint32_t '3'><uint32_t '4'>
 
 On the device side, we might read the data as follows:
 
 .. code-block:: sh
 
-	static int example_verb_sum_polar(struct command_transaction *trans)
-	{
-	    uint32_t sum_magnitude = 0, sum_angle = 0;
+  static int example_verb_sum_polar(struct command_transaction *trans)
+  {
+      uint32_t sum_magnitude = 0, sum_angle = 0;
 
-	    // While there's still data available in the string, grab vectors the data-stream.
-	    while (comms_argument_data_remaining(trans)) {
+      // While there's still data available in the string, grab vectors the data-stream.
+      while (comms_argument_data_remaining(trans)) {
 
-        	// Read the next pair of vector components from the data stream...
-        	uint32_t magnitude = comms_argument_parse_uint32_t(trans);
-        	uint32_t angle = comms_argument_parse_uint32_t(trans);
+          // Read the next pair of vector components from the data stream...
+          uint32_t magnitude = comms_argument_parse_uint32_t(trans);
+          uint32_t angle = comms_argument_parse_uint32_t(trans);
         
-        	// ... do your math here.
-        	// <left as an exercise to the reader>
-    	} 
+          // ... do your math here.
+          // <left as an exercise to the reader>
+      } 
 
-	    // Check to make sure we actually got all the pairs we tried to read.
-	    // If we didn't, this function will fail out!
-	    if (!comms_transaction_okay(trans)) {
-	        return EBADMSG;
-	    }
+      // Check to make sure we actually got all the pairs we tried to read.
+      // If we didn't, this function will fail out!
+      if (!comms_transaction_okay(trans)) {
+          return EBADMSG;
+      }
 
-	    // And respond with the relevant data.
-	    comms_response_add_uint32_t(trans, sum_magnitude);
-	    comms_response_add_uint32_t(trans, sum_angle);
-	    return 0;
-	}
+      // And respond with the relevant data.
+      comms_response_add_uint32_t(trans, sum_magnitude);
+      comms_response_add_uint32_t(trans, sum_angle);
+      return 0;
+  }
 
 In this case, we repeatedly call ``comms_argument_parse_uint32_t`` to capture each piece of the input stream; using ``comms_argument_data_remaining`` to check how much data is left.
 
@@ -335,5 +315,5 @@ Using this signature allows us to be flexible, but comes at a significant cost: 
 
 .. code-block:: sh
 
-	from pygreat.comms import CommsBackend
-	help(CommsBackend.execute_raw_command)
+  from pygreat.comms import CommsBackend
+  help(CommsBackend.execute_raw_command)

--- a/docs/source/libgreat_verb_signatures.rst
+++ b/docs/source/libgreat_verb_signatures.rst
@@ -44,7 +44,7 @@ Describing Verb Signatures
 Verb signatures are provided in a format that's heavily inspired by `Python's struct module <https://docs.python.org/2/library/struct.html>`__ -- in fact, the formats are mostly identical. To provide some additional flexibility, we support a few additional format characters. The standard and added format characters are described below:
 
 .. list-table:: Verb Signatures
-   :widths: 10 7 11 10 33 29  
+   :widths: 10 7 11 10 33 29
    :header-rows: 1
 
    * - Format
@@ -53,118 +53,118 @@ Verb signatures are provided in a format that's heavily inspired by `Python's st
      - Python Type
      - libgreat parse function
      - libgreat response function
-   * - x (1)
+   * - x *(1)*
      - 1
      - none
      - none
      - comms_argument_read_buffer( trans, 1, NULL )
      - comms_argument_read_buffer( trans, 1, NULL )
-   * - c  
-     - 1  
-     - char   
-     - string of length 1   
+   * - c
+     - 1
+     - char
+     - string of length 1
      - comms_argument_parse_uint8_t
      - comms_response_add_uint8_t
-   * - b  
-     - 1  
+   * - b
+     - 1
      - int8_t
-     - integer  
+     - integer
      - comms_argument_parse_int8_t
      - comms_response_add_int8_t
-   * - B  
-     - 1  
+   * - B
+     - 1
      - uint8_t
-     - integer  
+     - integer
      - comms_argument_parse_uint8_t
      - comms_response_add_uint8_t
-   * - ?  
-     - 1  
-     - bool / _Bool   
-     - integer  
+   * - ?
+     - 1
+     - bool / _Bool
+     - integer
      - comms_argument_parse_bool
      - comms_response_add_bool
-   * - h  
-     - 2  
+   * - h
+     - 2
      - int16_t
-     - integer  
+     - integer
      - comms_argument_parse_int16_t
      - comms_response_add_int16_t
-   * - H  
-     - 2  
+   * - H
+     - 2
      - uint16_t
-     - integer  
+     - integer
      - comms_argument_parse_uint16_t
      - comms_response_add_uint16_t
-   * - i  
-     - 4  
+   * - i
+     - 4
      - int32_t
-     - integer  
+     - integer
      - comms_argument_parse_int32_t
      - comms_response_add_int32_t
-   * - I  
-     - 4  
+   * - I
+     - 4
      - uint32_t
-     - integer  
+     - integer
      - comms_argument_parse_uint32_t
      - comms_response_add_uint32_t
-   * - l  
-     - 4  
+   * - l
+     - 4
      - int32_t
-     - integer  
+     - integer
      - comms_argument_parse_int32_t
      - comms_response_add_int32_t
-   * - L  
-     - 4  
+   * - L
+     - 4
      - uint32_t
-     - integer  
+     - integer
      - comms_argument_parse_uint32_t
      - comms_response_add_uint32_t
-   * - q  
-     - 8  
+   * - q
+     - 8
      - int64_t
-     - integer  
+     - integer
      - comms_argument_parse_int64_t
      - comms_response_add_int64_t
-   * - Q  
-     - 8  
+   * - Q
+     - 8
      - uint64_t
-     - integer  
+     - integer
      - comms_argument_parse_uint64_t
      - comms_response_add_uint64_t
-   * - f  
-     - 4  
+   * - f
+     - 4
      - float
-     - float  
+     - float
      - comms_argument_parse_float
      - comms_response_add_float
-   * - d  
-     - 8  
-     - double   
-     - float  
+   * - d
+     - 8
+     - double
+     - float
      - comms_argument_parse_double
      - comms_response_add_double
-   * - s (2) (3) (6)
-     -      
+   * - s *(2)(3)(6)*
+     - 
      - char[]
-     - string   
+     - string
      - comms_argument_read_buffer
      - comms_response_add_raw
-   * - p (2) (6)
-     -    
+   * - p *(2)(6)*
+     - 
      - char[]
-     - string   
+     - string
      - comms_argument_parse_uint8_t / comms_argument_read_buffer
      - comms_response_add_uint8_t / comms_response_add_raw
-   * - S (4)
-     -    
+   * - S *(4)*
+     - 
      - char[]
-     - string   
+     - string
      - comms_argument_read_string
      - comms_response_add_string
-   * - X (3) (5) (6)    
+   * - X *(3)(5)(6)*
      - 
      - uint8_t
-     - bytes of length 1  
+     - bytes of length 1
      - comms_argument_read_string
      - comms_response_add_string
 
@@ -173,19 +173,19 @@ Verb signatures are provided in a format that's heavily inspired by `Python's st
   :header-rows: 1
   :widths: 1 2
 
-  * - note number   
+  * - note number
     - description
-  * - (1)   
+  * - *(1)*
     - null padding byte; rarely used
-  * - (2)   
+  * - *(2)*
     - see python docs
-  * - (3)   
+  * - *(3)*
     - typically used with a numeric prefix
-  * - (4)   
+  * - *(4)*
     - encodes a null-terminated string
-  * - (5)   
+  * - *(5)*
     - encodes raw bytes; repeated elements are merged into a single entry
-  * - (6)   
+  * - *(6)*
     - numeric prefixes behave differently; see below
 
 ``libgreat`` data is always of standard size, and *always* little-endian. **Accordingly, every non-empty method signature must begin with a '<'.** Exceptions are made for methods that expect no arguments or return no values, which can provide an empty string.
@@ -224,13 +224,13 @@ A handful of format specifiers interpret numeric prefixes as *element lengths*, 
   :header-rows: 1
   :widths: 1 3
 
-  * - type  
+  * - type
     - interpretation
-  * - s   
+  * - s
     - the specified element represents a string of N characters, where N is the length specifier
-  * - p   
+  * - p
     - the specified element represents a pascal string of maximum length N, where N is the length specifier
-  * - X   
+  * - X
     - the specified element represents a string of N bytes, where N is the length specifier
 
 For the ``s`` and ``X`` specifiers, a length specifier of ``*`` indicates that the relevant string can be expected to take up all of the remaining data. Note that the format ``S`` does accepts a *repeat specifier* and **not** a *length specifier*, so the string ``32S`` denotes 32 null-terminated strings.
@@ -256,7 +256,7 @@ It may help to consider an example RPC with the following meta-data:
 
   { .name = "sum_polar", .handler = example_verb_sum_polar, .in_signature = "<*(II)",
       .out_signature = "<II", .in_param_names = "magnitudes_and_angles", .out_param_names = "sum_magnitude, sum_angle",
-      .doc = "Sums together a collection of polar coordinates." },  
+      .doc = "Sums together a collection of polar coordinates." },
 
 The method's in-signature, ``<*(II)``, demonstrates that the method expects any number of *two-element pairs*, which each contain a pair of integers. Accordingly, we might call it as follows:
 


### PR DESCRIPTION
Closes #408 

To review this pull request, navigate into the docs folder from command line and then type "make latexpdf". You may be required to install a bunch of latex software to view the PDF. Once the make command exits without an error you can navigate from the 'docs' folder to 'build' to 'latex'. The PDF of the documentation will be in that folder. The table that I have fixed is on page 22 of the documentation. 