### PR TITLE
Packaging: migrate from setup.py to pyproject.toml

### DIFF
--- a/ci-scripts/build-host.sh
+++ b/ci-scripts/build-host.sh
@@ -5,10 +5,8 @@ python3 -m venv testing-venv
 source testing-venv/bin/activate
 pip3 install pyyaml
 pushd libgreat/host/
-python3 setup.py build
-python3 setup.py install
+pip3 install .
 popd
 pushd host/
-python3 setup.py build
-python3 setup.py install
+pip3 install .
 popd

--- a/host/pyproject.toml
+++ b/host/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "greatfet"
 dynamic = ["version"]
 authors = [
-    {name = "Great Scott Gadgets", email = "ktemkin@greatscottgadgets.com"},
+    {name = "Great Scott Gadgets", email = "dev@greatscottgadgets.com"},
 ]
 license = { text = "BSD" }
 description = "Python library for hardware hacking with the GreatFET"
@@ -14,7 +14,7 @@ urls = { Source = "https://greatscottgadgets.com/greatfet" }
 readme = "README.md"
 classifiers = [
     "Programming Language :: Python",
-    "Development Status :: 1 - Planning",
+    "Development Status :: 5 - Production/Stable",
     "Natural Language :: English",
     "Environment :: Console",
     "Environment :: Plugins",
@@ -67,9 +67,3 @@ greatfet_chipcon = "greatfet.commands.greatfet_chipcon:main"
 [tool.setuptools-git-versioning]
 enabled = true
 starting_version = "2019.05.01"
-
-#[tool.setuptools]
-#packages = ["greatfet"]
-
-#[tool.setuptools.packages.find]
-#where = ["greatfet"]

--- a/host/setup.py
+++ b/host/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
This PR contains:

1. Metadata updates for authors and development status
2. A shim for `setup.py` as CI still relies on a `python setup.py` flow
3. Update `libgreat` git submodule to HEAD
4. Modifies `ci-scripts/build-host.sh` to use `pip3 install .` instead of `python setup.py ...`