### PR TITLE
Fix for the gf shell. Supports newer versions of IPython, v3.11+

### DIFF
--- a/host/greatfet/commands/greatfet_shell.py
+++ b/host/greatfet/commands/greatfet_shell.py
@@ -15,7 +15,6 @@ from greatfet.utils import GreatFETArgumentParser
 from greatfet.util.interactive import GreatFETShellMagics
 
 import IPython
-from IPython.terminal.interactiveshell import TerminalInteractiveShell
 
 def main():
 
@@ -69,7 +68,12 @@ def main():
 
 
     # Create a new shell, and give it access to our created GreatFET object.
-    shell = TerminalInteractiveShell()
+    # Apr 18 2023 - Changed method for creating the shell, to support changes in IPython v8.11+
+    #             - ref. https://github.com/ipython/ipython/issues/13966
+    if IPython.core.getipython.get_ipython() is None:
+        shell = IPython.terminal.embed.InteractiveShellEmbed.instance()
+    else:
+        shell = IPython.terminal.embed.InteractiveShellEmbed()
     shell.push('gf')
 
     # Create nice aliases for our primary interfaces.

--- a/host/greatfet/commands/greatfet_shell.py
+++ b/host/greatfet/commands/greatfet_shell.py
@@ -68,8 +68,6 @@ def main():
 
 
     # Create a new shell, and give it access to our created GreatFET object.
-    # Apr 18 2023 - Changed method for creating the shell, to support changes in IPython v8.11+
-    #             - ref. https://github.com/ipython/ipython/issues/13966
     if IPython.core.getipython.get_ipython() is None:
         shell = IPython.terminal.embed.InteractiveShellEmbed.instance()
     else:


### PR DESCRIPTION
IPython.terminal broke the greatfet shell such that any attempt to use it resulted in an exception ending in:
`Exception 'NoneType' object has no attribute 'check_complete'`

This was traced to a change in IPython, version 8.11 and has broken other projects as well, refer to this issue in the IPython project: https://github.com/ipython/ipython/issues/13966

This PR fixes the problem, as suggested in the issue report (linked above). It should be compatible with IPython v8.11 and later, and also backwards compatible for earlier versions of the library as well (as per the above issues last comment).

I tested the raw Python script (greatefet_shell.py) but have not managed to generate an install (.egg ?) using the README instructions. The .py file, when run directly, no longer creates an exception and the shell runs normally.

Please review for a merge or copy the simple change to your repo...

Alternatively, you could mention in the Docs that this issue can be fixed by rolling back IPython to an earlier version using pip3, (ver 8.10) although this is a sub-optimal alternative as all other, non greatfet, Python3 user scripts will now be forced to use the same older version of the library.
