### PR TITLE
gpio: add support for configuring all gpio pin modes

### DIFF
--- a/firmware/greatfet_usb/classes/gpio.c
+++ b/firmware/greatfet_usb/classes/gpio.c
@@ -18,8 +18,19 @@
 // This file's class number.
 #define CLASS_NUMBER_SELF (0x103)
 
+// Convenience type to cast between a pin configuration register and its 32 bit value.
+typedef union {
+	gpio_pin_configuration_t reg;
+	uint32_t bits;
+} pin_configuration_t;
+
+
 static int gpio_verb_set_up_gpio_pin(struct command_transaction *trans)
 {
+	/**
+	 * Deprecated: prefer gpio_verb_configure_gpio_pin
+	 */
+	
 	gpio_pin_t gpio_pin;
 
 	int rc;
@@ -78,6 +89,90 @@ static int gpio_verb_set_up_gpio_pin(struct command_transaction *trans)
 
 	return 0;
 }
+
+
+static int gpio_verb_configure_gpio_pin(struct command_transaction *trans)
+{
+	gpio_pin_t gpio_pin;
+	uint8_t as_output, initial_value;
+	pin_configuration_t configuration;
+
+	uint8_t scu_group, scu_pin;
+	int rc;
+	
+	gpio_pin_configuration_t scu_pin_configuration;
+	
+	gpio_pin.port      = comms_argument_parse_uint8_t(trans);
+	gpio_pin.pin       = comms_argument_parse_uint8_t(trans);
+	as_output          = comms_argument_parse_uint8_t(trans);
+	initial_value      = comms_argument_parse_uint8_t(trans);
+	configuration.bits = comms_argument_parse_uint32_t(trans);
+
+	if (!comms_transaction_okay(trans)) {
+		return EBADMSG;
+	}
+
+	// First, ensure we can access the given pin.
+	scu_group = gpio_get_group_number(gpio_pin);
+	scu_pin   = gpio_get_pin_number(gpio_pin);
+
+	// If this port/pin doesn't correspond to a valid physical pin,
+	// fail out.
+	if ((scu_group == 0xff) || (scu_pin == 0xff)) {
+		return EINVAL;
+	}
+
+	// If we can't get a hold on the given pin.
+	if (!pin_ensure_reservation(scu_group, scu_pin, CLASS_NUMBER_SELF)) {
+		pr_warning("gpio: couldn't reserve busy pin GPIO%d[%d]!\n", gpio_pin.port, gpio_pin.pin);
+		return EBUSY;
+	}
+
+	// Set the pin's SCU configuration.
+	if (as_output) {
+		// Set the pin's slew rate.
+		scu_pin_configuration.use_fast_slew = configuration.reg.use_fast_slew;
+
+		// If the given pin is a high-drive pin, set the drive strength.
+		scu_pin_configuration.drive_strength = configuration.reg.drive_strength;
+		
+	} else {
+		// Set the pin's resistor mode.
+		scu_pin_configuration.pull_resistors = configuration.reg.pull_resistors;
+
+		// Set the pin's input buffer mode.
+		scu_pin_configuration.input_buffer_enabled = configuration.reg.input_buffer_enabled;
+
+		// Set the pin's glitch_filter mode.
+		scu_pin_configuration.disable_glitch_filter = configuration.reg.disable_glitch_filter;
+	}
+
+	// Configure the pin to be used as a GPIO in the SCU.
+	rc = gpio_configure_pinmux_and_pin(gpio_pin, scu_pin_configuration);
+	if (rc) {
+		pr_warning("couldn't configure pinmux for GPIO%d[%d]\n", gpio_pin.port, gpio_pin.pin);
+		return rc;
+	}
+
+	// If this is an output pin, set its initial value.
+	if (as_output) {
+		rc = gpio_set_pin_value(gpio_pin, initial_value);
+		if (rc) {
+			pr_warning("couldn't set initial value for GPIO%d[%d]\n", gpio_pin.port, gpio_pin.pin);
+			return rc;
+		}
+	}
+
+	// Set the initial direction of the port pin.
+	rc = gpio_set_pin_direction(gpio_pin, as_output);
+	if (rc) {
+		pr_warning("couldn't set initial direction for GPIO%d[%d]\n", gpio_pin.port, gpio_pin.pin);
+		return rc;
+	}
+			
+	return 0;
+}
+
 
 static int gpio_verb_release_pin(struct command_transaction *trans)
 {
@@ -158,6 +253,46 @@ static int gpio_verb_get_pin_directions(struct command_transaction *trans)
 }
 
 
+static int gpio_verb_get_pin_configurations(struct command_transaction *trans)
+{
+    uint8_t scu_group, scu_pin;
+    gpio_pin_t gpio_pin;
+
+	platform_scu_registers_t *scu;	
+	pin_configuration_t value;
+	
+    // Continue for as long as we have pins to handle.
+    while (comms_argument_data_remaining(trans)) {
+
+		// Parse the current port/pin pair...
+		gpio_pin.port = comms_argument_parse_uint8_t(trans);
+		gpio_pin.pin  = comms_argument_parse_uint8_t(trans);
+
+		if (!comms_transaction_okay(trans)) {
+			return EBADMSG;
+		}
+
+		// First, ensure we can access the given pin.
+		scu_group = gpio_get_group_number(gpio_pin);
+		scu_pin = gpio_get_pin_number(gpio_pin);
+
+		// If this port/pin doesn't correspond to a valid physical pin,
+		// fail out.
+		if ((scu_group == 0xff) || (scu_pin == 0xff)) {
+			return EINVAL;
+		}
+
+		// Read the scu pin configuration register block
+		scu = platform_get_scu_registers();
+		value.reg = scu->group[scu_group].pin[scu_pin];
+
+		comms_response_add_uint32_t(trans, value.bits);
+    }
+
+    return 0;
+}
+
+
 static int gpio_verb_write_pins(struct command_transaction *trans)
 {
 	int rc;
@@ -191,8 +326,8 @@ static int gpio_verb_write_pins(struct command_transaction *trans)
 static struct comms_verb _verbs[] = {
 
 		/* Configuration. */
-		{  .name = "set_up_pin", .handler = gpio_verb_set_up_gpio_pin, .in_signature = "<BBBB",
-		   .out_signature = "", .in_param_names = "port, pin, as_output, initial_value",
+		{  .name = "configure_pin", .handler = gpio_verb_configure_gpio_pin, .in_signature = "<BBBBI",
+		   .out_signature = "", .in_param_names = "port, pin, as_output, initial_value, configuration",
 		   .doc = "Configures a single pin to be used for GPIO." },
 		{  .name = "release_pin", .handler = gpio_verb_release_pin, .in_signature = "<BB",
 		   .out_signature = "", .in_param_names = "port, pin",
@@ -201,6 +336,10 @@ static struct comms_verb _verbs[] = {
 		   .out_signature = "<*B", .in_param_names = "pins", .out_param_names = "directions",
 		   .doc = "Reads the direction of a GPIO pin or pins given tuples of (port, pin)."
 			   "Returns 1 for output; 0 for input." },
+		{  .name = "get_pin_configurations", .handler = gpio_verb_get_pin_configurations, .in_signature = "<*(BB)",
+		   .out_signature = "<*I", .in_param_names = "pins", .out_param_names = "configurations",
+		   .doc = "Reads the SCU pin configuration registers of a GPIO pin or pins given tuples of (port, pin)."
+			  "Returns the 32 bit SCU configuration register block for each pin." },
 
 		/* Pin access functions. */
 		{  .name = "read_pins", .handler = gpio_verb_read_pins, .in_signature = "<*(BB)",
@@ -213,9 +352,13 @@ static struct comms_verb _verbs[] = {
 
 		/* TODO: Port access functions. */
 
+		/* Deprecated verbs. */
+		{  .name = "set_up_pin", .handler = gpio_verb_set_up_gpio_pin, .in_signature = "<BBBB",
+		   .out_signature = "", .in_param_names = "port, pin, as_output, initial_value",
+		   .doc = "gpio.set_up_pin is deprecated; prefer configure_pin." },
+
 		/* Sentinel. */
 		{}
 };
 COMMS_DEFINE_SIMPLE_CLASS(gpio, CLASS_NUMBER_SELF, "gpio", _verbs,
 		"API for simple GPIO manipulations.");
-

--- a/host/greatfet/examples/gpio_pin_modes.py
+++ b/host/greatfet/examples/gpio_pin_modes.py
@@ -1,0 +1,83 @@
+import time
+
+import greatfet
+from greatfet.interfaces import gpio
+
+#
+# We will be using the followng GPIO pins:
+#
+#   Inputs:
+#     SGPIO0 -- J1_P4  -- (0,0)
+#     SGPIO1 -- J1_P6  -- (0,1)
+#     SGPIO2 -- J1_P28 -- (0,2)
+#     SGPIO3 -- J1_P30 -- (0,3)
+#
+#   Outputs:
+#     SGPIO4 -- J2_P36 -- (3,2)
+#     SGPIO5 -- J2_P34 -- (0,5)
+#     SGPIO6 -- J2_P33 -- (5,2)
+#     SGPIO7 -- J1_P7  -- (0,4)
+#
+
+def main():
+    gf = greatfet.GreatFET()
+    
+    (line0, line1, line2, line3) = ((0,0), (0,1), (0,2), (0,3))
+    (line4, line5, line6, line7) = ((3,2), (0,5), (5,2), (0,4))
+    
+    # - Configure inputs --
+    
+    # Via gpio.configure_pin()...
+    gf.gpio.configure_pin(line0, gpio.InputConfiguration(gpio.PullResistor.PULLDOWN))
+    gf.gpio.configure_pin(
+        line1,
+        gpio.InputConfiguration(
+            pull_resistor=gpio.PullResistor.PULLDOWN,
+            glitch_filter=gpio.GlitchFilter.DISABLE
+        )
+    )
+
+    # ...or via gf.gpio.get_pin()
+    pin2 = gf.gpio.get_pin("J1_P28")
+    pin2.set_configuration(gpio.InputConfiguration(
+        pull_resistor=gpio.PullResistor.PULLDOWN,
+        glitch_filter=gpio.GlitchFilter.ENABLE,
+    ))
+    pin3 = gf.gpio.get_pin("J1_P30")
+    pin3.set_direction(gpio.Directions.IN, configuration=gpio.InputConfiguration(
+        pull_resistor=gpio.PullResistor.PULLDOWN,
+    ))
+    
+    # - Configure outputs --
+
+    # Via gpio.configure_pin()...    
+    gf.gpio.configure_pin(line4, gpio.OutputConfiguration(), initial_value=False)
+    gf.gpio.configure_pin(line5,  gpio.OutputConfiguration(        
+        slew_rate=gpio.SlewRate.SLOW,
+    ), initial_value=True)
+    
+    # ...or via gf.gpio.get_pin()
+    pin6 = gf.gpio.get_pin("J2_P33")
+    pin6.set_direction(gpio.Directions.OUT, initial_value=False)
+    pin7 = gf.gpio.get_pin("J1_P7")
+    pin7.set_configuration(gpio.OutputConfiguration(slew_rate=gpio.SlewRate.FAST), initial_value=True)
+
+    blinky = True    
+    while True:
+        state0 = gf.gpio.read_pin_state(line0)
+        state1 = gf.gpio.read_pin_state(line1)
+        state2 = pin2.read()
+        state3 = pin3.read()
+        print(f"SGPIO0:{state0} SGPIO1:{state1} SGPIO2:{state2} SGPIO3:{state3}")
+
+        gf.gpio.set_pin_state(line4, blinky)
+        gf.gpio.set_pin_state(line5, blinky)
+        pin6.write(blinky)
+        pin7.write(blinky)
+        blinky = not blinky
+        
+        time.sleep(0.5)
+        
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds support for configuring all of GreatFET's gpio pin modes:

```python
from greatfet.interfaces.gpio import Directions, InputConfiguration, OutputConfiguration, PullResistor, GlitchFilter, SlewRate

# You can configure pins via gpio.configure_pin():

gf.gpio.configure_pin((0,0), InputConfiguration(PullResistor.PULLDOWN))
gf.gpio.configure_pin((0,0), InputConfiguration(
        pull_resistor=PullResistor.PULLDOWN,
        glitch_filter=GlitchFilter.DISABLE,
    )
)
gf.gpio.configure_pin((0,0), OutputConfiguration(), False)
gf.gpio.configure_pin((0,0), OutputConfiguration(SlewRate.SLOW), initial_value=False)


# Or, if you prefer, directly on the pin:

pin = gf.gpio.get_pin("J1_P4")
pin.set_configuration(InputConfiguration(PullResistor.PULLDOWN))
pin.set_configuration(InputConfiguration(PullResistor.PULLDOWN, GlitchFilter.DISABLE))

# Or, even in other ways you may be accustomed:

pin = gf.gpio.get_pin("J1_P4")
pin.set_direction(Directions.OUT, True, OutputConfiguration(
        slew_rate=SlewRate.FAST
    )
)
```

See [host/greatfet/examples/gpio_pin_modes.py](https://github.com/antoinevg/greatfet/blob/antoinevg/gpio-mode/host/greatfet/examples/gpio_pin_modes.py) for more examples.

Supporting Pull Requests:

* https://github.com/greatscottgadgets/libgreat/pull/34 
* https://github.com/greatscottgadgets/libgreat/pull/35

References:

* https://github.com/greatscottgadgets/greatfet/issues/141
* https://github.com/greatscottgadgets/greatfet/issues/135
