### PR TITLE
greatdancer: fix facedancer usb mass storage example not working

### DIFF
--- a/firmware/greatfet_usb/classes/greatdancer.c
+++ b/firmware/greatfet_usb/classes/greatdancer.c
@@ -26,7 +26,7 @@
 
 #define CLASS_NUMBER_SELF (0x104)
 
-typedef char packet_buffer[4096];
+typedef char packet_buffer[512];
 
 /**
  *	Buffers for each of the relevant endpoints.


### PR DESCRIPTION
This commit reverts 516d98a and fixes #373.
