### PR TITLE
Fix import pkg_resources error on some python distributions

### DIFF
--- a/host/greatfet/commands/greatfet_info.py
+++ b/host/greatfet/commands/greatfet_info.py
@@ -82,10 +82,10 @@ def print_host_info():
 
 
     try:
-        import pkg_resources
+        import importlib.metadata
 
-        gf_version = pkg_resources.require("greatfet")[0].version
-        pygreat_version = pkg_resources.require("pygreat")[0].version
+        gf_version = importlib.metadata.version("greatfet")
+        pygreat_version = importlib.metadata.version("pygreat")
 
         print('\thost module version: {}'.format(gf_version))
         print('\tpygreat module version: {}'.format(pygreat_version))

--- a/host/pyproject.toml
+++ b/host/pyproject.toml
@@ -27,10 +27,12 @@ classifiers = [
 ]
 
 dependencies = [
+    "importlib_resources; python_version<'3.9'",
     "pyusb",
     "future",
     "pyfwup>=0.2",
     "tqdm",
+    "setuptools",    # cmsis_svd requires pkg_resources
     "cmsis_svd",
     "tabulate",
     "prompt_toolkit",


### PR DESCRIPTION
Newer versions of Python no longer ship with `setuptools` by default which can cause problems with older code.

This PR:

1. Modernizes the GreatFET Host tools to use `importlib.metada` instead of `pkg_resources.require("...")[0].version`
2. Adds `setuptools` to the package dependencies as `cmsis-svd` still uses `pkg_resources` and does not specify it in its dependencies.