### PR TITLE
Fix gf shell not being able to access globals inside user defined functions.

### DIFF
--- a/host/greatfet/commands/greatfet_shell.py
+++ b/host/greatfet/commands/greatfet_shell.py
@@ -66,12 +66,15 @@ def main():
         singleton_text = "singleton " if args.singleton else ""
         print("A GreatFET {}object has been created for you as 'gf'. Have fun!\n".format(singleton_text))
 
+    # Mute annoying venv warning.
+    config = IPython.terminal.ipapp.load_default_config()
+    config.InteractiveShell.warn_venv = False
 
     # Create a new shell, and give it access to our created GreatFET object.
     if IPython.core.getipython.get_ipython() is None:
-        shell = IPython.terminal.embed.InteractiveShellEmbed.instance()
+        shell = IPython.terminal.interactiveshell.TerminalInteractiveShell.instance(config=config)
     else:
-        shell = IPython.terminal.embed.InteractiveShellEmbed()
+        shell = IPython.terminal.interactiveshell.TerminalInteractiveShell(config=config)
     shell.push('gf')
 
     # Create nice aliases for our primary interfaces.

--- a/host/pyproject.toml
+++ b/host/pyproject.toml
@@ -32,12 +32,12 @@ dependencies = [
     "future",
     "pyfwup>=0.2",
     "tqdm",
-    "setuptools",    # cmsis_svd requires pkg_resources
+    "setuptools",     # cmsis_svd requires pkg_resources
     "cmsis_svd",
     "tabulate",
     "prompt_toolkit",
     "pygreat",
-    "ipython~=8.25",
+    "ipython~=8.12",  # final version supported by Python 3.8
 ]
 
 dynamic = ["version"]


### PR DESCRIPTION
This PR fixes an issue introduced in #414 where executing the following code in the GreatFET shell will fail with a `NameError: name 'time' is not defined error`:

```python
import time
def read(x):
    time.sleep(x)
    print("Done")
read(2)
```

The fix has been tested on IPython versions `8.12.3` and `8.26.0`.

This PR also rolls back the version of IPython specified in the package dependencies to `"ipython~=8.12"` as this was the final version supported by Python 3.8 which is our minimum Python specification for the package.

The current latest version IPython is `8.26.0` which requires Python `>=3.10`.

If GreatFET is installed on systems with Python `>=3.10` then the dependency spec `~=8.12` will resolve as: `>=8.12, ==8.*` .

This ensures that the latest IPython will be installed on those systems.

---
Closes #435