### PR TITLE
corrected udev rules

### DIFF
--- a/host/util/54-greatfet.rules
+++ b/host/util/54-greatfet.rules
@@ -1,2 +1,2 @@
-SUBSYSTEM=="usb", ATTR{idVendor}=="1d50", ATTR{idProduct}=="60e6", SYMLINK+="greatfet-one%k", TAG+="uaccess", MODE:="0660"
-SUBSYSTEM=="usb", ATTR{idVendor}=="1fc9", ATTR{idProduct}=="000c", SYMLINK+="nxp-dfu-%k", TAG+="uaccess", MODE:="0660"
+SUBSYSTEM=="usb", ATTR{idVendor}=="1d50", ATTR{idProduct}=="60e6", SYMLINK+="greatfet-one%k", TAG+="uaccess", MODE:="0660", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTR{idVendor}=="1fc9", ATTR{idProduct}=="000c", SYMLINK+="nxp-dfu-%k", TAG+="uaccess", MODE:="0660", GROUP="plugdev"

--- a/host/util/54-greatfet.rules
+++ b/host/util/54-greatfet.rules
@@ -1,2 +1,2 @@
-SUBSYSTEM=="usb", ATTR{idVendor}=="1d50", ATTR{idProduct}=="60e6", SYMLINK+="greatfet-one%k", TAG+="uaccess"
-SUBSYSTEM=="usb", ATTR{idVendor}=="1fc9", ATTR{idProduct}=="000c", SYMLINK+="nxp-dfu-%k", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTR{idVendor}=="1d50", ATTR{idProduct}=="60e6", SYMLINK+="greatfet-one%k", TAG+="uaccess", MODE:="0660"
+SUBSYSTEM=="usb", ATTR{idVendor}=="1fc9", ATTR{idProduct}=="000c", SYMLINK+="nxp-dfu-%k", TAG+="uaccess", MODE:="0660"


### PR DESCRIPTION
If `MODE:="0660"` is not included as part of the udev rule, then udev defaults to `0600` permissions, which makes the device inaccessible to normal users. Previous modification broke functionality without use of `sudo` by removing `MODE:="0660"`.

UPDATED:

Adding `MODE:` to the udev rule definition was tested twice before submitting the pull request and supported by documentation in the ArchLinux Wiki [^1]. This modification proceeded to cease providing a resolution in use when the reset button on the device was pressed. This is more than likely associated with the device being reassigned to a different bus.

Proposed Change:

So, the proposed change is to add back both `MODE:` and `GROUP` to the udev rule definition in order to prevent breaking access for users[^2]. Which, to be frank, should have never been removed. The flag `TAG+="uaccess"` is dependent on the service `systemd-logind` which is not universally implemented on Linux, and most important of all, `systemd-logind` is triggered independently of the ssh-server-service. Which means, relying on `systemd-logind` to provide accessibility to the device, will result in breaking accessibility for the users who desire a more "bare-boned" configuration and want to use their device remotely.

Leaving `TAG+="uaccess"`, while adding back `MODE:` and `GROUP`, provides functionality for both approaches. 

[^1]: [Allowing regular users...](https://wiki.archlinux.org/title/Udev#Allowing_regular_users_to_use_devices)
[^2]: [Rfcat udev rules](https://github.com/atlas0fd00m/rfcat/blob/master/etc/udev/rules.d/20-rfcat.rules)